### PR TITLE
Implement waypoints layers model

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -149,5 +149,9 @@ export default [
                 ...globals.jest,
             },
         },
+        rules: {
+            // Allow chai assertions like expect().to.be.true
+            '@typescript-eslint/no-unused-expressions': 'off',
+        },
     },
 ];

--- a/jest.config.js
+++ b/jest.config.js
@@ -42,5 +42,10 @@ module.exports = {
             displayName: 'node-red',
             testRegex: 'modules/node-red/.*\\.spec\\.ts$',
         },
+        {
+            ...baseConfig,
+            displayName: 'browser',
+            testRegex: 'modules/browser/.*\\.spec\\.ts$',
+        },
     ],
 };

--- a/modules/browser/src/gallery/mocks/space-driver.ts
+++ b/modules/browser/src/gallery/mocks/space-driver.ts
@@ -63,6 +63,10 @@ export function createMockWaypoint(
     overrides: Partial<{
         id: string;
         position: XY;
+        collection: string;
+        owner: string | null;
+        title: string;
+        color: number;
     }> = {},
 ): Waypoint {
     const waypoint = new Waypoint();
@@ -70,6 +74,18 @@ export function createMockWaypoint(
     if (overrides.position) {
         waypoint.position.x = overrides.position.x;
         waypoint.position.y = overrides.position.y;
+    }
+    if (overrides.collection !== undefined) {
+        waypoint.collection = overrides.collection;
+    }
+    if (overrides.owner !== undefined) {
+        waypoint.owner = overrides.owner;
+    }
+    if (overrides.title !== undefined) {
+        waypoint.title = overrides.title;
+    }
+    if (overrides.color !== undefined) {
+        waypoint.color = overrides.color;
     }
     return waypoint;
 }

--- a/modules/browser/src/radar/waypoint-layers-store.ts
+++ b/modules/browser/src/radar/waypoint-layers-store.ts
@@ -1,0 +1,266 @@
+import EventEmitter from 'eventemitter3';
+import { SpaceDriver, Waypoint } from '@starwards/core';
+
+export type WaypointLayersStoreEvents = 'visibilityChanged' | 'activeLayerChanged' | 'changed';
+
+/**
+ * Client-side store to track which waypoint layers are displayed.
+ *
+ * This store manages the visibility state of waypoint layers (collections)
+ * and tracks which layer is currently active for editing operations.
+ *
+ * @example
+ * ```typescript
+ * const store = new WaypointLayersStore();
+ * store.init(spaceDriver, shipId);
+ *
+ * // Show only 'route' layer
+ * store.hideAllLayers();
+ * store.setLayerVisible('route', true);
+ *
+ * // Use with ObjectsLayer
+ * const waypointsLayer = new ObjectsLayer(
+ *     root, spaceDriver, 32,
+ *     (w) => w.color,
+ *     tacticalDrawWaypoints,
+ *     undefined,
+ *     store.createVisibilityFilter(),
+ * );
+ * ```
+ */
+export class WaypointLayersStore {
+    public readonly events = new EventEmitter<WaypointLayersStoreEvents>();
+
+    /** Which layers (collections) are currently visible */
+    private visibleLayers = new Set<string>();
+
+    /** Which layer is currently active for editing */
+    private activeLayer: string | null = null;
+
+    /** Ship ID to filter waypoints (optional - if set, only waypoints owned by this ship are considered) */
+    private shipId: string | null = null;
+
+    /** Space driver for accessing waypoints */
+    private spaceDriver: SpaceDriver | null = null;
+
+    /**
+     * Initialize the store with a space driver and optional ship ID.
+     * If shipId is provided, only waypoints owned by that ship will be considered.
+     *
+     * @param spaceDriver - The space driver to get waypoints from
+     * @param shipId - Optional ship ID to filter waypoints by owner
+     */
+    init(spaceDriver: SpaceDriver, shipId?: string): this {
+        this.spaceDriver = spaceDriver;
+        this.shipId = shipId ?? null;
+
+        // Initially show all available layers
+        const layers = this.getAvailableLayers();
+        for (const layer of layers) {
+            this.visibleLayers.add(layer);
+        }
+
+        return this;
+    }
+
+    /**
+     * Get all available layer names from the current waypoints.
+     * Returns unique collection names from all waypoints (filtered by shipId if set).
+     */
+    getAvailableLayers(): string[] {
+        if (!this.spaceDriver) {
+            return [];
+        }
+
+        const layers = new Set<string>();
+        for (const waypoint of this.spaceDriver.state.getAll('Waypoint')) {
+            if (this.matchesShipFilter(waypoint)) {
+                layers.add(waypoint.collection);
+            }
+        }
+
+        return [...layers].sort();
+    }
+
+    /**
+     * Check if a waypoint matches the ship filter (if any).
+     */
+    private matchesShipFilter(waypoint: Waypoint): boolean {
+        if (this.shipId === null) {
+            return true;
+        }
+        return waypoint.owner === this.shipId;
+    }
+
+    /**
+     * Check if a layer is currently visible.
+     */
+    isLayerVisible(layerName: string): boolean {
+        return this.visibleLayers.has(layerName);
+    }
+
+    /**
+     * Set the visibility of a specific layer.
+     */
+    setLayerVisible(layerName: string, visible: boolean): void {
+        const wasVisible = this.visibleLayers.has(layerName);
+        if (visible && !wasVisible) {
+            this.visibleLayers.add(layerName);
+            this.emitChange('visibilityChanged');
+        } else if (!visible && wasVisible) {
+            this.visibleLayers.delete(layerName);
+            this.emitChange('visibilityChanged');
+        }
+    }
+
+    /**
+     * Toggle the visibility of a specific layer.
+     */
+    toggleLayerVisibility(layerName: string): void {
+        this.setLayerVisible(layerName, !this.isLayerVisible(layerName));
+    }
+
+    /**
+     * Show all available layers.
+     */
+    showAllLayers(): void {
+        const layers = this.getAvailableLayers();
+        let changed = false;
+        for (const layer of layers) {
+            if (!this.visibleLayers.has(layer)) {
+                this.visibleLayers.add(layer);
+                changed = true;
+            }
+        }
+        if (changed) {
+            this.emitChange('visibilityChanged');
+        }
+    }
+
+    /**
+     * Hide all layers.
+     */
+    hideAllLayers(): void {
+        if (this.visibleLayers.size > 0) {
+            this.visibleLayers.clear();
+            this.emitChange('visibilityChanged');
+        }
+    }
+
+    /**
+     * Get the names of all currently visible layers.
+     */
+    getVisibleLayers(): string[] {
+        return [...this.visibleLayers];
+    }
+
+    /**
+     * Get the currently active layer (for editing operations).
+     */
+    getActiveLayer(): string | null {
+        return this.activeLayer;
+    }
+
+    /**
+     * Set the active layer for editing operations.
+     * Setting to null means no layer is active.
+     */
+    setActiveLayer(layerName: string | null): void {
+        if (this.activeLayer !== layerName) {
+            this.activeLayer = layerName;
+            this.emitChange('activeLayerChanged');
+        }
+    }
+
+    /**
+     * Cycle to the next available layer as active.
+     * If no layer is active, activates the first available layer.
+     * If the last layer is active, cycles back to the first.
+     */
+    cycleActiveLayer(): void {
+        const layers = this.getAvailableLayers();
+        if (layers.length === 0) {
+            this.setActiveLayer(null);
+            return;
+        }
+
+        if (this.activeLayer === null) {
+            this.setActiveLayer(layers[0]);
+            return;
+        }
+
+        const currentIndex = layers.indexOf(this.activeLayer);
+        if (currentIndex === -1 || currentIndex === layers.length - 1) {
+            this.setActiveLayer(layers[0]);
+        } else {
+            this.setActiveLayer(layers[currentIndex + 1]);
+        }
+    }
+
+    /**
+     * Create a filter function for use with ObjectsLayer.
+     * The filter returns true for waypoints that:
+     * 1. Match the ship filter (if set)
+     * 2. Are in a visible layer
+     *
+     * @param additionalFilter - Optional additional filter to apply
+     * @returns A filter function suitable for ObjectsLayer
+     */
+    createVisibilityFilter(additionalFilter?: (waypoint: Waypoint) => boolean): (waypoint: Waypoint) => boolean {
+        return (waypoint: Waypoint) => {
+            // Check ship filter
+            if (!this.matchesShipFilter(waypoint)) {
+                return false;
+            }
+
+            // Check layer visibility
+            if (!this.visibleLayers.has(waypoint.collection)) {
+                return false;
+            }
+
+            // Apply additional filter if provided
+            if (additionalFilter && !additionalFilter(waypoint)) {
+                return false;
+            }
+
+            return true;
+        };
+    }
+
+    /**
+     * Get the alpha value for a waypoint based on whether it's in the active layer.
+     * Active layer waypoints get full opacity (1.0), others get reduced opacity.
+     *
+     * @param inactiveAlpha - Alpha value for waypoints not in the active layer (default: 0.5)
+     * @returns A function that returns the alpha value for a waypoint
+     */
+    createAlphaFunction(inactiveAlpha = 0.5): (waypoint: Waypoint) => number {
+        return (waypoint: Waypoint) => {
+            // If no active layer is set, all waypoints get full opacity
+            if (this.activeLayer === null) {
+                return 1;
+            }
+            // Active layer gets full opacity, others get reduced
+            return waypoint.collection === this.activeLayer ? 1 : inactiveAlpha;
+        };
+    }
+
+    /**
+     * Subscribe to store changes.
+     *
+     * @param event - The event type to listen for, or 'changed' for any change
+     * @param callback - The callback to invoke when the event fires
+     * @returns A function to unsubscribe
+     */
+    onChange(event: WaypointLayersStoreEvents, callback: () => void): () => void {
+        this.events.on(event, callback);
+        return () => {
+            this.events.off(event, callback);
+        };
+    }
+
+    private emitChange(event: 'visibilityChanged' | 'activeLayerChanged'): void {
+        this.events.emit(event);
+        this.events.emit('changed');
+    }
+}

--- a/modules/browser/src/radar/waypoint-layers-store.ts
+++ b/modules/browser/src/radar/waypoint-layers-store.ts
@@ -1,5 +1,6 @@
-import EventEmitter from 'eventemitter3';
 import { SpaceDriver, Waypoint } from '@starwards/core';
+
+import EventEmitter from 'eventemitter3';
 
 export type WaypointLayersStoreEvents = 'visibilityChanged' | 'activeLayerChanged' | 'changed';
 

--- a/modules/browser/test/waypoint-layers-store.spec.ts
+++ b/modules/browser/test/waypoint-layers-store.spec.ts
@@ -1,0 +1,285 @@
+import { createMockSpaceDriver, createMockWaypoint } from '../src/gallery/mocks/space-driver';
+import { SpaceDriver } from '@starwards/core';
+import { WaypointLayersStore } from '../src/radar/waypoint-layers-store';
+import { expect } from 'chai';
+
+describe('WaypointLayersStore', () => {
+    describe('initialization', () => {
+        it('should initialize with no visible layers when no waypoints exist', () => {
+            const store = new WaypointLayersStore();
+            const spaceDriver = createMockSpaceDriver([]);
+            store.init(spaceDriver as unknown as SpaceDriver);
+
+            expect(store.getAvailableLayers()).to.deep.equal([]);
+            expect(store.getVisibleLayers()).to.deep.equal([]);
+        });
+
+        it('should show all available layers after init', () => {
+            const waypoints = [
+                createMockWaypoint({ id: 'wp1', collection: 'route' }),
+                createMockWaypoint({ id: 'wp2', collection: 'markers' }),
+                createMockWaypoint({ id: 'wp3', collection: 'route' }),
+            ];
+            const store = new WaypointLayersStore();
+            const spaceDriver = createMockSpaceDriver(waypoints);
+            store.init(spaceDriver as unknown as SpaceDriver);
+
+            expect(store.getAvailableLayers()).to.deep.equal(['markers', 'route']);
+            expect(store.getVisibleLayers().sort()).to.deep.equal(['markers', 'route']);
+        });
+
+        it('should filter waypoints by shipId when provided', () => {
+            const waypoints = [
+                createMockWaypoint({ id: 'wp1', collection: 'route', owner: 'ship1' }),
+                createMockWaypoint({ id: 'wp2', collection: 'markers', owner: 'ship2' }),
+                createMockWaypoint({ id: 'wp3', collection: 'targets', owner: 'ship1' }),
+            ];
+            const store = new WaypointLayersStore();
+            const spaceDriver = createMockSpaceDriver(waypoints);
+            store.init(spaceDriver as unknown as SpaceDriver, 'ship1');
+
+            expect(store.getAvailableLayers()).to.deep.equal(['route', 'targets']);
+        });
+    });
+
+    describe('layer visibility', () => {
+        let store: WaypointLayersStore;
+
+        beforeEach(() => {
+            const waypoints = [
+                createMockWaypoint({ id: 'wp1', collection: 'route' }),
+                createMockWaypoint({ id: 'wp2', collection: 'markers' }),
+                createMockWaypoint({ id: 'wp3', collection: 'targets' }),
+            ];
+            store = new WaypointLayersStore();
+            const spaceDriver = createMockSpaceDriver(waypoints);
+            store.init(spaceDriver as unknown as SpaceDriver);
+        });
+
+        it('should report layer visibility correctly', () => {
+            expect(store.isLayerVisible('route')).to.be.true;
+            expect(store.isLayerVisible('markers')).to.be.true;
+            expect(store.isLayerVisible('nonexistent')).to.be.false;
+        });
+
+        it('should set layer visibility', () => {
+            store.setLayerVisible('route', false);
+            expect(store.isLayerVisible('route')).to.be.false;
+
+            store.setLayerVisible('route', true);
+            expect(store.isLayerVisible('route')).to.be.true;
+        });
+
+        it('should toggle layer visibility', () => {
+            expect(store.isLayerVisible('route')).to.be.true;
+
+            store.toggleLayerVisibility('route');
+            expect(store.isLayerVisible('route')).to.be.false;
+
+            store.toggleLayerVisibility('route');
+            expect(store.isLayerVisible('route')).to.be.true;
+        });
+
+        it('should hide all layers', () => {
+            store.hideAllLayers();
+            expect(store.getVisibleLayers()).to.deep.equal([]);
+        });
+
+        it('should show all layers', () => {
+            store.hideAllLayers();
+            store.showAllLayers();
+            expect(store.getVisibleLayers().sort()).to.deep.equal(['markers', 'route', 'targets']);
+        });
+
+        it('should emit visibilityChanged event when visibility changes', () => {
+            let visibilityEventCount = 0;
+            let changedEventCount = 0;
+
+            store.onChange('visibilityChanged', () => visibilityEventCount++);
+            store.onChange('changed', () => changedEventCount++);
+
+            store.setLayerVisible('route', false);
+            expect(visibilityEventCount).to.equal(1);
+            expect(changedEventCount).to.equal(1);
+
+            // Setting to the same value should not emit
+            store.setLayerVisible('route', false);
+            expect(visibilityEventCount).to.equal(1);
+            expect(changedEventCount).to.equal(1);
+        });
+    });
+
+    describe('active layer', () => {
+        let store: WaypointLayersStore;
+
+        beforeEach(() => {
+            const waypoints = [
+                createMockWaypoint({ id: 'wp1', collection: 'route' }),
+                createMockWaypoint({ id: 'wp2', collection: 'markers' }),
+                createMockWaypoint({ id: 'wp3', collection: 'targets' }),
+            ];
+            store = new WaypointLayersStore();
+            const spaceDriver = createMockSpaceDriver(waypoints);
+            store.init(spaceDriver as unknown as SpaceDriver);
+        });
+
+        it('should have no active layer initially', () => {
+            expect(store.getActiveLayer()).to.be.null;
+        });
+
+        it('should set and get active layer', () => {
+            store.setActiveLayer('route');
+            expect(store.getActiveLayer()).to.equal('route');
+
+            store.setActiveLayer(null);
+            expect(store.getActiveLayer()).to.be.null;
+        });
+
+        it('should cycle through available layers', () => {
+            store.cycleActiveLayer();
+            expect(store.getActiveLayer()).to.equal('markers');
+
+            store.cycleActiveLayer();
+            expect(store.getActiveLayer()).to.equal('route');
+
+            store.cycleActiveLayer();
+            expect(store.getActiveLayer()).to.equal('targets');
+
+            store.cycleActiveLayer();
+            expect(store.getActiveLayer()).to.equal('markers'); // Wraps around
+        });
+
+        it('should emit activeLayerChanged event when active layer changes', () => {
+            let activeLayerEventCount = 0;
+            let changedEventCount = 0;
+
+            store.onChange('activeLayerChanged', () => activeLayerEventCount++);
+            store.onChange('changed', () => changedEventCount++);
+
+            store.setActiveLayer('route');
+            expect(activeLayerEventCount).to.equal(1);
+            expect(changedEventCount).to.equal(1);
+
+            // Setting to the same value should not emit
+            store.setActiveLayer('route');
+            expect(activeLayerEventCount).to.equal(1);
+            expect(changedEventCount).to.equal(1);
+        });
+    });
+
+    describe('visibility filter', () => {
+        it('should create a filter that passes visible layers', () => {
+            const waypoints = [
+                createMockWaypoint({ id: 'wp1', collection: 'route', owner: 'ship1' }),
+                createMockWaypoint({ id: 'wp2', collection: 'markers', owner: 'ship1' }),
+            ];
+            const store = new WaypointLayersStore();
+            const spaceDriver = createMockSpaceDriver(waypoints);
+            store.init(spaceDriver as unknown as SpaceDriver, 'ship1');
+
+            const filter = store.createVisibilityFilter();
+
+            expect(filter(waypoints[0])).to.be.true;
+            expect(filter(waypoints[1])).to.be.true;
+
+            store.setLayerVisible('route', false);
+            expect(filter(waypoints[0])).to.be.false;
+            expect(filter(waypoints[1])).to.be.true;
+        });
+
+        it('should filter by ship owner', () => {
+            const wp1 = createMockWaypoint({ id: 'wp1', collection: 'route', owner: 'ship1' });
+            const wp2 = createMockWaypoint({ id: 'wp2', collection: 'route', owner: 'ship2' });
+
+            const store = new WaypointLayersStore();
+            const spaceDriver = createMockSpaceDriver([wp1, wp2]);
+            store.init(spaceDriver as unknown as SpaceDriver, 'ship1');
+
+            const filter = store.createVisibilityFilter();
+
+            expect(filter(wp1)).to.be.true;
+            expect(filter(wp2)).to.be.false;
+        });
+
+        it('should apply additional filter', () => {
+            const wp1 = createMockWaypoint({ id: 'wp1', collection: 'route', title: 'keep' });
+            const wp2 = createMockWaypoint({ id: 'wp2', collection: 'route', title: 'remove' });
+
+            const store = new WaypointLayersStore();
+            const spaceDriver = createMockSpaceDriver([wp1, wp2]);
+            store.init(spaceDriver as unknown as SpaceDriver);
+
+            const filter = store.createVisibilityFilter((wp) => wp.title === 'keep');
+
+            expect(filter(wp1)).to.be.true;
+            expect(filter(wp2)).to.be.false;
+        });
+    });
+
+    describe('alpha function', () => {
+        it('should return 1 for all waypoints when no active layer', () => {
+            const waypoints = [
+                createMockWaypoint({ id: 'wp1', collection: 'route' }),
+                createMockWaypoint({ id: 'wp2', collection: 'markers' }),
+            ];
+            const store = new WaypointLayersStore();
+            const spaceDriver = createMockSpaceDriver(waypoints);
+            store.init(spaceDriver as unknown as SpaceDriver);
+
+            const alphaFn = store.createAlphaFunction();
+
+            expect(alphaFn(waypoints[0])).to.equal(1);
+            expect(alphaFn(waypoints[1])).to.equal(1);
+        });
+
+        it('should return 1 for active layer and reduced for others', () => {
+            const waypoints = [
+                createMockWaypoint({ id: 'wp1', collection: 'route' }),
+                createMockWaypoint({ id: 'wp2', collection: 'markers' }),
+            ];
+            const store = new WaypointLayersStore();
+            const spaceDriver = createMockSpaceDriver(waypoints);
+            store.init(spaceDriver as unknown as SpaceDriver);
+
+            store.setActiveLayer('route');
+            const alphaFn = store.createAlphaFunction();
+
+            expect(alphaFn(waypoints[0])).to.equal(1);
+            expect(alphaFn(waypoints[1])).to.equal(0.5);
+        });
+
+        it('should use custom inactive alpha value', () => {
+            const waypoints = [
+                createMockWaypoint({ id: 'wp1', collection: 'route' }),
+                createMockWaypoint({ id: 'wp2', collection: 'markers' }),
+            ];
+            const store = new WaypointLayersStore();
+            const spaceDriver = createMockSpaceDriver(waypoints);
+            store.init(spaceDriver as unknown as SpaceDriver);
+
+            store.setActiveLayer('route');
+            const alphaFn = store.createAlphaFunction(0.3);
+
+            expect(alphaFn(waypoints[0])).to.equal(1);
+            expect(alphaFn(waypoints[1])).to.equal(0.3);
+        });
+    });
+
+    describe('event unsubscription', () => {
+        it('should allow unsubscribing from events', () => {
+            const store = new WaypointLayersStore();
+            const spaceDriver = createMockSpaceDriver([createMockWaypoint({ collection: 'route' })]);
+            store.init(spaceDriver as unknown as SpaceDriver);
+
+            let eventCount = 0;
+            const unsubscribe = store.onChange('changed', () => eventCount++);
+
+            store.setLayerVisible('route', false);
+            expect(eventCount).to.equal(1);
+
+            unsubscribe();
+            store.setLayerVisible('route', true);
+            expect(eventCount).to.equal(1); // Should not have increased
+        });
+    });
+});

--- a/modules/core/test/ship-manager.spec.ts
+++ b/modules/core/test/ship-manager.spec.ts
@@ -77,7 +77,7 @@ describe.each([ShipManagerPc, ShipManagerNpc])('%p', (shipManagerCtor) => {
                         //@ts-ignore : access private property
                         shipMgr.damageManager.getNumberOfBrokenPlatesInRange(expectedHitPlatesRange);
                     expect(brokenInsideExplosion).to.equal(brokenTotal);
-                    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+
                     expect(shipMgr.state.chainGun!.broken).to.be.false;
                     expect(shipMgr.state.chainGun!.angleOffset).to.equal(0);
                     expect(shipMgr.state.chainGun!.rateOfFireFactor).to.equal(1);

--- a/modules/core/test/space-manager.spec.ts
+++ b/modules/core/test/space-manager.spec.ts
@@ -248,7 +248,6 @@ describe('SpaceManager', () => {
             sim.withObjects(scanner, target);
             sim.spaceMgr.forceFlushEntities();
 
-            // eslint-disable-next-line @typescript-eslint/no-unused-expressions
             expect(sim.spaceMgr.canScan(scanner.id, target.id)).to.be.true;
         });
 
@@ -266,7 +265,6 @@ describe('SpaceManager', () => {
             sim.withObjects(scanner, target);
             sim.spaceMgr.forceFlushEntities();
 
-            // eslint-disable-next-line @typescript-eslint/no-unused-expressions
             expect(sim.spaceMgr.canScan(scanner.id, target.id)).to.be.false;
         });
 


### PR DESCRIPTION
Client-side store to track which waypoint layers are displayed. Features:
- Track visibility state per layer (collection)
- Track active layer for editing operations
- createVisibilityFilter() for use with ObjectsLayer
- createAlphaFunction() for visual distinction of active layer
- Event-based change notifications