### PR TITLE
feat: Zellij dev layout for one-command dev environment

### DIFF
--- a/.zellij/dev.kdl
+++ b/.zellij/dev.kdl
@@ -1,0 +1,35 @@
+// Starwards dev layout: 2x2 grid with core-watch, server, browser, tests
+// Usage: npm run dev (inside Zellij) or zellij action new-tab --layout .zellij/dev.kdl
+
+layout {
+    default_tab_template {
+        pane size=1 borderless=true {
+            plugin location="https://github.com/ishefi/zellaude/releases/latest/download/zellaude.wasm"
+        }
+        children
+        pane size=1 borderless=true {
+            plugin location="status-bar"
+        }
+    }
+
+    tab name="starwards-dev" cwd="/data/Workspace/helios/starwards" {
+        pane split_direction="vertical" {
+            pane split_direction="horizontal" {
+                pane name="core-watch" cwd="modules/core" command="npm" {
+                    args "run" "build:watch"
+                }
+                pane name="server" command="bash" {
+                    args "scripts/wait-for-core.sh"
+                }
+            }
+            pane split_direction="horizontal" {
+                pane name="browser" cwd="modules/browser" command="npm" {
+                    args "start"
+                }
+                pane name="tests" command="npm" focus=true {
+                    args "test" "--" "--watchAll"
+                }
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "modules/*"
     ],
     "scripts": {
+        "dev": "bash scripts/dev.sh",
         "clean": "rimraf ./modules/browser/dist ./modules/browser/dist ./modules/core/cjs ./modules/server/cjs",
         "postbuild": "node scripts/post-build.js",
         "pretty-quick": "pretty-quick --staged --pattern \"./modules/*/src/**/*.{ts,tsx,json}\"",

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Launch starwards dev environment in Zellij
+# Server pane starts as empty shell — run server manually after core finishes initial build
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+zellij action new-tab --layout "$PROJECT_DIR/.zellij/dev.kdl"

--- a/scripts/wait-for-core.sh
+++ b/scripts/wait-for-core.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Wait for a fresh core build, then start the server.
+# tsup's clean:true deletes cjs/ before each build (including watch mode),
+# so we wait for the file to disappear then reappear to ensure a fresh build.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+CORE_OUTPUT="$PROJECT_DIR/modules/core/cjs/index.js"
+
+echo "Waiting for core watch to start..."
+
+# Phase 1: wait for tsup to clean the output (file disappears)
+while [ -f "$CORE_OUTPUT" ]; do
+    sleep 0.5
+done
+echo "Core build cleaning detected..."
+
+# Phase 2: wait for fresh build to complete (file reappears)
+while [ ! -f "$CORE_OUTPUT" ]; do
+    sleep 0.5
+done
+echo "Core build ready. Starting server..."
+
+cd "$PROJECT_DIR/modules/server" && exec npm run start


### PR DESCRIPTION
## Summary
- Adds `.zellij/dev.kdl` layout with 2x2 grid: core-watch, server, browser, tests
- Server pane uses `scripts/wait-for-core.sh` to wait for core's initial build before starting (avoids module-not-found race)
- Adds `npm run dev` script to launch the layout from within a Zellij session

## Usage
```bash
# Inside Zellij
npm run dev
# or
zellij action new-tab --layout .zellij/dev.kdl
```

## Test plan
- [ ] Run `npm run dev` inside a Zellij session
- [ ] Confirm 4 panes appear in a "starwards-dev" tab
- [ ] Confirm server waits for core build before starting
- [ ] Confirm all processes start successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)