### PR TITLE
feat: wire chaingun widget into weapons station screen

### DIFF
--- a/modules/browser/src/screens/weapons.ts
+++ b/modules/browser/src/screens/weapons.ts
@@ -8,6 +8,7 @@ import $ from 'jquery';
 import ElementQueries from 'css-element-queries/src/ElementQueries';
 import { InputManager } from '../input/input-manager';
 import { drawAmmoStatus } from '../widgets/ammo';
+import { drawGunStatus } from '../widgets/gun';
 import { drawSystemsStatus } from '../widgets/system-status';
 import { drawTacticalRadar } from '../widgets/tactical-radar';
 import { drawTargetingStatus } from '../widgets/targeting';
@@ -61,6 +62,7 @@ async function initScreen(driver: Driver, shipId: string) {
     drawTubesStatus(container.subContainer(VPos.TOP, HPos.LEFT), shipDriver);
     drawAmmoStatus(container.subContainer(VPos.MIDDLE, HPos.LEFT), shipDriver);
     drawTargetingStatus(container.subContainer(VPos.MIDDLE, HPos.RIGHT), shipDriver);
+    drawGunStatus(container.subContainer(VPos.BOTTOM, HPos.LEFT), shipDriver);
 }
 
 function wireInput(shipDriver: ShipDriver) {
@@ -75,5 +77,9 @@ function wireInput(shipDriver: ShipDriver) {
     input.addMomentaryClickAction(writeProp(shipDriver, '/tubes/0/isFiring'), 'x');
     input.addToggleClickAction(readWriteProp(shipDriver, '/tubes/0/loadAmmo'), 'c');
     input.addMomentaryClickAction(writeProp(shipDriver, '/tubes/0/changeProjectileCommand'), 'v');
+
+    input.addMomentaryClickAction(writeProp(shipDriver, '/chainGun/isFiring'), 'f');
+    input.addToggleClickAction(readWriteProp(shipDriver, '/chainGun/loadAmmo'), 'g');
+    input.addMomentaryClickAction(writeProp(shipDriver, '/chainGun/changeProjectileCommand'), 'b');
     input.init();
 }

--- a/modules/browser/src/widgets/gun.ts
+++ b/modules/browser/src/widgets/gun.ts
@@ -13,8 +13,13 @@ export function drawGunStatus(container: WidgetContainer, shipDriver: ShipDriver
         pane.dispose();
     });
     container.on('destroy', panelCleanup.destroy);
-    addTextBlade(pane, readProp(shipDriver, '/chainGun/projectile'), { label: 'ammo to use' }, panelCleanup.add);
-    addTextBlade(pane, readProp(shipDriver, '/chainGun/loadedProjectile'), { label: 'ammo loaded' }, panelCleanup.add);
+    addTextBlade(pane, readProp(shipDriver, '/chainGun/projectile'), { label: 'projectile' }, panelCleanup.add);
+    addTextBlade(
+        pane,
+        readProp(shipDriver, '/chainGun/loadedProjectile'),
+        { label: 'loaded projectile' },
+        panelCleanup.add,
+    );
     addSliderBlade(
         pane,
         readNumberProp(shipDriver, '/chainGun/loading'),

--- a/modules/browser/src/widgets/gun.ts
+++ b/modules/browser/src/widgets/gun.ts
@@ -1,8 +1,28 @@
+import { Destructors, ShipDriver } from '@starwards/core';
+import { addInputBlade, addSliderBlade, addTextBlade, createPane } from '../panel/blades';
+import { readNumberProp, readProp } from '../property-wrappers';
+
 import { DashboardWidget } from './dashboard';
 import { PropertyPanel } from '../panel';
-import { ShipDriver } from '@starwards/core';
 import { WidgetContainer } from '../container';
-import { readNumberProp } from '../property-wrappers';
+
+export function drawGunStatus(container: WidgetContainer, shipDriver: ShipDriver) {
+    const panelCleanup = new Destructors();
+    const pane = createPane({ title: 'Chain Gun', container: container.getElement().get(0) });
+    panelCleanup.add(() => {
+        pane.dispose();
+    });
+    container.on('destroy', panelCleanup.destroy);
+    addTextBlade(pane, readProp(shipDriver, '/chainGun/projectile'), { label: 'ammo to use' }, panelCleanup.add);
+    addTextBlade(pane, readProp(shipDriver, '/chainGun/loadedProjectile'), { label: 'ammo loaded' }, panelCleanup.add);
+    addSliderBlade(
+        pane,
+        readNumberProp(shipDriver, '/chainGun/loading'),
+        { label: 'loading', disabled: true },
+        panelCleanup.add,
+    );
+    addInputBlade(pane, readProp(shipDriver, '/chainGun/loadAmmo'), { label: 'auto load' }, panelCleanup.add);
+}
 
 export function gunWidget(shipDriver: ShipDriver): DashboardWidget {
     class GunComponent {

--- a/modules/e2e/test/weapons-screen.spec.ts
+++ b/modules/e2e/test/weapons-screen.spec.ts
@@ -25,6 +25,7 @@ test.describe('Weapons Screen', () => {
         await expect(page.locator('[data-id="Tubes Status"]')).toBeVisible();
         await expect(page.locator('[data-id="Targeting"]')).toBeVisible();
         await expect(page.locator('[data-id="Ammunition"]')).toBeVisible();
+        await expect(page.locator('[data-id="Chain Gun"]')).toBeVisible();
 
         // Note: targetId sync test removed - setting state directly doesn't trigger UI sync
         // Verify ammo to use syncs


### PR DESCRIPTION
Add Chain Gun panel to the weapons screen at bottom-left position with
ammo selection, loading progress, and auto-load controls. Add keyboard
bindings: f (fire), g (toggle auto-load), b (change projectile type).

https://claude.ai/code/session_01Xv2r9ZJf2JLHE1p99iCREW