### PR TITLE
Implement scan level visibility for radar blips

### DIFF
--- a/modules/browser/src/colors.ts
+++ b/modules/browser/src/colors.ts
@@ -25,6 +25,7 @@ export const radar = {
     azimuthTint: 0x00ffff, // Pure cyan
     shellTint: 0xff6600, // Orange (secondary)
     deflectionTint: 0x00aaff, // Cyan-blue
+    unknownTint: 0x666666, // Dim gray for UFO/unscanned objects
 };
 
 // ============================================================================

--- a/modules/browser/src/radar/blips/blip-renderer.ts
+++ b/modules/browser/src/radar/blips/blip-renderer.ts
@@ -1,5 +1,5 @@
 import { Assets, Container, Graphics, Sprite, Text, TextStyle, Texture } from 'pixi.js';
-import { Asteroid, SpaceObject, Spaceship, Waypoint } from '@starwards/core';
+import { Asteroid, ScanLevel, SpaceObject, Spaceship, Waypoint } from '@starwards/core';
 import { radar, selectionColor, white } from '../../colors';
 
 import { CameraView } from '../camera-view';
@@ -11,6 +11,7 @@ export interface BlipData {
     stage: Container;
     parent: CameraView;
     blipSize: number;
+    scanLevel: ScanLevel;
 }
 
 export interface BlipRenderer<T extends SpaceObject> {
@@ -82,19 +83,25 @@ class DradisSpaceshipRenderer implements BlipRenderer<Spaceship> {
         stage.addChild(this.selectionSprite);
     }
 
-    redraw(spaceObject: Spaceship, { parent, isSelected, color, alpha }: BlipData): void {
-        this.directionSprite.angle = (spaceObject.angle - parent.camera.angle) % 360;
-        this.text.text = `ID: ${spaceObject.id}`;
-        this.text.x = -this.text.getLocalBounds().width / 2;
+    redraw(spaceObject: Spaceship, { parent, isSelected, color, alpha, scanLevel }: BlipData): void {
+        const identified = scanLevel >= ScanLevel.BASIC;
+        this.fighterSprite.visible = identified;
+        this.directionSprite.visible = identified;
+        this.text.visible = identified;
+        if (identified) {
+            this.directionSprite.angle = (spaceObject.angle - parent.camera.angle) % 360;
+            this.text.text = `ID: ${spaceObject.id}`;
+            this.text.x = -this.text.getLocalBounds().width / 2;
+            this.fighterSprite.tint = color;
+            this.fighterSprite.alpha = alpha;
+        }
         this.collisionOutline.clear();
         this.collisionOutline
             .circle(0, 0, parent.metersToPixles(spaceObject.radius))
-            .stroke({ width: 1, color: radar.collisionOutline, alpha: 0.5 });
+            .stroke({ width: 1, color: identified ? radar.collisionOutline : color, alpha: 0.5 });
         this.selectionSprite.visible = isSelected;
         this.circleBevelSprite.tint = color;
         this.circleBevelSprite.alpha = alpha;
-        this.fighterSprite.tint = color;
-        this.fighterSprite.alpha = alpha;
     }
 }
 class DradisAsteroidRenderer implements BlipRenderer<Asteroid> {
@@ -161,18 +168,23 @@ class TacticalSpaceshipRenderer implements BlipRenderer<Spaceship> {
         stage.addChild(this.selectionSprite);
     }
 
-    redraw(spaceObject: Spaceship, { parent, isSelected, blipSize, color, alpha }: BlipData): void {
-        this.fighterSprite.angle = (spaceObject.angle - parent.camera.angle) % 360;
-        this.fighterSprite.tint = color;
-        this.fighterSprite.alpha = alpha;
-        this.fighterSprite.height = blipSize;
-        this.fighterSprite.width = blipSize;
-        this.text.text = `ID: ${spaceObject.id}`;
-        this.text.x = -this.text.getLocalBounds().width / 2;
+    redraw(spaceObject: Spaceship, { parent, isSelected, blipSize, color, alpha, scanLevel }: BlipData): void {
+        const identified = scanLevel >= ScanLevel.BASIC;
+        this.fighterSprite.visible = identified;
+        this.text.visible = identified;
+        if (identified) {
+            this.fighterSprite.angle = (spaceObject.angle - parent.camera.angle) % 360;
+            this.fighterSprite.tint = color;
+            this.fighterSprite.alpha = alpha;
+            this.fighterSprite.height = blipSize;
+            this.fighterSprite.width = blipSize;
+            this.text.text = `ID: ${spaceObject.id}`;
+            this.text.x = -this.text.getLocalBounds().width / 2;
+        }
         this.collisionOutline.clear();
         this.collisionOutline
             .circle(0, 0, parent.metersToPixles(spaceObject.radius))
-            .stroke({ width: 1, color: radar.collisionOutline, alpha: 0.5 });
+            .stroke({ width: 1, color: identified ? radar.collisionOutline : color, alpha: 0.5 });
         this.selectionSprite.visible = isSelected;
         this.selectionSprite.height = blipSize;
         this.selectionSprite.width = blipSize;

--- a/modules/browser/src/radar/blips/objects-layer.ts
+++ b/modules/browser/src/radar/blips/objects-layer.ts
@@ -1,10 +1,10 @@
 import { BlipData, BlipRenderer } from './blip-renderer';
 import { Container, UPDATE_PRIORITY } from 'pixi.js';
-import { SpaceDriver, SpaceObject, SpaceObjects, XY } from '@starwards/core';
+import { Faction, ScanLevel, SpaceDriver, SpaceObject, SpaceObjects, XY } from '@starwards/core';
 
 import { CameraView } from '../camera-view';
 import { TrackObjects } from '../track-objects';
-import { white } from '../../colors';
+import { radar, white } from '../../colors';
 
 type RenderFunctions<K extends keyof SpaceObjects> = {
     [T in K]: {
@@ -19,16 +19,33 @@ type Blip<K extends keyof SpaceObjects> = readonly [BlipRenderer<SpaceObjects[K]
 export class ObjectsLayer<K extends keyof SpaceObjects = keyof SpaceObjects> {
     private stage = new Container();
 
+    private getScanLevel(o: SpaceObject): ScanLevel {
+        if (this.playerFaction === undefined) {
+            return ScanLevel.ADVANCED;
+        }
+        const factionIndex = Number(this.playerFaction);
+        const rawLevel =
+            factionIndex >= 0 && factionIndex < o.scanLevels.length
+                ? (o.scanLevels[factionIndex] as ScanLevel | undefined) ?? ScanLevel.UFO
+                : ScanLevel.UFO;
+        // Same-faction objects are always at least BASIC
+        if (o.faction === this.playerFaction && this.playerFaction !== Faction.NONE) {
+            return Math.max(rawLevel, ScanLevel.BASIC) as ScanLevel;
+        }
+        return rawLevel;
+    }
+
     private createBlip = (spaceObject: SpaceObjects[K]): Blip<K> => {
         const stage = new Container();
         const renderer = new this.drawFunctions[spaceObject.type as K](stage, this.blipSize);
-        const data = {
+        const data: BlipData = {
             isSelected: false,
             color: white,
             stage,
             parent: this.parent,
             blipSize: this.blipSize,
             alpha: 1,
+            scanLevel: ScanLevel.ADVANCED,
         };
         this.updateBlip(spaceObject, [renderer, data]);
         this.stage.addChild(data.stage);
@@ -46,7 +63,9 @@ export class ObjectsLayer<K extends keyof SpaceObjects = keyof SpaceObjects> {
             g.stage.y - g.stage.height < this.parent.renderer.height;
         if (shouldRedraw) {
             g.isSelected = Boolean(this.selectedItems?.has(o));
-            g.color = this.getColor(o);
+            g.scanLevel = this.getScanLevel(o);
+            const identifiedColor = this.getColor(o);
+            g.color = g.scanLevel >= ScanLevel.BASIC ? identifiedColor : radar.unknownTint;
             g.alpha = this.getAlpha(o);
             r.redraw(o, g);
         }
@@ -77,6 +96,7 @@ export class ObjectsLayer<K extends keyof SpaceObjects = keyof SpaceObjects> {
         private readonly filter?: Filter<K>,
         private readonly position: Positioning<K> = (o: SpaceObjects[K]) => this.parent.worldToScreen(o.position),
         private readonly getAlpha: (s: SpaceObjects[K]) => number = () => 1,
+        private readonly playerFaction?: Faction,
     ) {
         parent.ticker.add(this.blips.update, UPDATE_PRIORITY.LOW);
     }

--- a/modules/browser/src/radar/blips/objects-layer.ts
+++ b/modules/browser/src/radar/blips/objects-layer.ts
@@ -2,9 +2,9 @@ import { BlipData, BlipRenderer } from './blip-renderer';
 import { Container, UPDATE_PRIORITY } from 'pixi.js';
 import { Faction, ScanLevel, SpaceDriver, SpaceObject, SpaceObjects, XY } from '@starwards/core';
 
+import { radar, white } from '../../colors';
 import { CameraView } from '../camera-view';
 import { TrackObjects } from '../track-objects';
-import { radar, white } from '../../colors';
 
 type RenderFunctions<K extends keyof SpaceObjects> = {
     [T in K]: {
@@ -26,7 +26,7 @@ export class ObjectsLayer<K extends keyof SpaceObjects = keyof SpaceObjects> {
         const factionIndex = Number(this.playerFaction);
         const rawLevel =
             factionIndex >= 0 && factionIndex < o.scanLevels.length
-                ? (o.scanLevels[factionIndex] as ScanLevel | undefined) ?? ScanLevel.UFO
+                ? ((o.scanLevels[factionIndex] as ScanLevel | undefined) ?? ScanLevel.UFO)
                 : ScanLevel.UFO;
         // Same-faction objects are always at least BASIC
         if (o.faction === this.playerFaction && this.playerFaction !== Faction.NONE) {

--- a/modules/browser/src/widgets/long-range-radar.ts
+++ b/modules/browser/src/widgets/long-range-radar.ts
@@ -173,6 +173,9 @@ export async function drawLongRangeRadar(
         tacticalDrawFunctions,
         targetContainer,
         rangeFilter.isInRange,
+        undefined,
+        undefined,
+        shipDriver.state.faction,
     );
 
     blipLayer.renderRoot.mask = circleMask;

--- a/modules/browser/src/widgets/pilot-radar.ts
+++ b/modules/browser/src/widgets/pilot-radar.ts
@@ -107,6 +107,9 @@ export async function drawPilotRadar(spaceDriver: SpaceDriver, shipDriver: ShipD
         tacticalDrawFunctions,
         shipTarget,
         rangeFilter.isInRange,
+        undefined,
+        undefined,
+        shipDriver.state.faction,
     );
     contentElements.addChild(blipLayer.renderRoot);
     const waypointsInRange = new ObjectsLayer(

--- a/modules/browser/src/widgets/radar.ts
+++ b/modules/browser/src/widgets/radar.ts
@@ -89,6 +89,9 @@ export function radarWidget(spaceDriver: SpaceDriver, shipDriver: ShipDriver): D
                 dradisDrawFunctions,
                 new SelectionContainer().init(spaceDriver),
                 rangeFilter.isInRange,
+                undefined,
+                undefined,
+                shipDriver.state.faction,
             );
             root.addLayer(blipLayer.renderRoot);
         }

--- a/modules/browser/src/widgets/tactical-radar.ts
+++ b/modules/browser/src/widgets/tactical-radar.ts
@@ -112,6 +112,9 @@ export async function drawTacticalRadar(
         tacticalDrawFunctions,
         shipTarget,
         rangeFilter.isInRange,
+        undefined,
+        undefined,
+        shipDriver.state.faction,
     );
 
     blipLayer.renderRoot.mask = circleMask;

--- a/modules/browser/src/widgets/target-radar.ts
+++ b/modules/browser/src/widgets/target-radar.ts
@@ -84,6 +84,9 @@ export function targetRadarWidget(spaceDriver: SpaceDriver, shipDriver: ShipDriv
                 tacticalDrawFunctions,
                 shipTarget,
                 rangeFilter.isInRange,
+                undefined,
+                undefined,
+                shipDriver.state.faction,
             );
             root.addLayer(blipLayer.renderRoot);
             trackObject(camera, spaceDriver.events, shipTarget);

--- a/modules/core/src/json-ptr.ts
+++ b/modules/core/src/json-ptr.ts
@@ -160,7 +160,12 @@ export class JsonPointer {
         if (current instanceof MapSchema) {
             throw new Error('Cannot set property on MapSchema - target should be an object in the map');
         } else if (current instanceof ArraySchema) {
-            throw new Error('Cannot set property on ArraySchema - target should be an element in the array');
+            const index = typeof finalSegment === 'number' ? finalSegment : parseInt(String(finalSegment), 10);
+            if (isNaN(index)) {
+                throw new Error(`Invalid array index: ${String(finalSegment)}`);
+            }
+            previousValue = (current as unknown as unknown[])[index];
+            (current as unknown as unknown[])[index] = value;
         } else if (current instanceof Schema) {
             previousValue = Reflect.get(current, finalSegment);
             // Use Reflect.set to ensure we go through the setter

--- a/modules/core/src/range.ts
+++ b/modules/core/src/range.ts
@@ -1,7 +1,7 @@
 import 'reflect-metadata';
 
-import { JsonPointer, getJsonPointer } from './json-ptr';
 import { ArraySchema, MapSchema, Schema } from '@colyseus/schema';
+import { JsonPointer, getJsonPointer } from './json-ptr';
 
 import { RTuple2 } from './logic/formulas';
 

--- a/modules/core/src/range.ts
+++ b/modules/core/src/range.ts
@@ -1,7 +1,7 @@
 import 'reflect-metadata';
 
 import { JsonPointer, getJsonPointer } from './json-ptr';
-import { MapSchema, Schema } from '@colyseus/schema';
+import { ArraySchema, MapSchema, Schema } from '@colyseus/schema';
 
 import { RTuple2 } from './logic/formulas';
 
@@ -109,6 +109,12 @@ function getParent(root: Schema, path: readonly (string | number)[]): unknown {
         if (current instanceof MapSchema) {
             // MapSchema requires .get() method
             current = current.get(String(segment));
+        } else if (current instanceof ArraySchema) {
+            const index = typeof segment === 'number' ? segment : parseInt(String(segment), 10);
+            if (isNaN(index)) {
+                return undefined;
+            }
+            current = (current as unknown as unknown[])[index];
         } else if (current instanceof Object) {
             // Regular object property access
             current = (current as Record<string | number, unknown>)[segment];
@@ -127,12 +133,16 @@ function getParent(root: Schema, path: readonly (string | number)[]): unknown {
 export function tryGetRange(root: Schema, pointer: JsonPointer): undefined | RTuple2 {
     const target = pointer.path.length === 1 ? root : getParent(root, pointer.path);
     const propertyName = pointer.path.at(-1);
-    if (!(target instanceof Object) || typeof propertyName !== 'string') {
+    if (!(target instanceof Object) || (typeof propertyName !== 'string' && typeof propertyName !== 'number')) {
         throw new Error(
             `pointer ${pointer.pointer} does not point at a legal location: target=${JSON.stringify(
                 target,
             )}, propertyName=${JSON.stringify(propertyName)}`,
         );
+    }
+    // ArraySchema elements have no range metadata
+    if (target instanceof ArraySchema || typeof propertyName !== 'string') {
+        return undefined;
     }
     if (!(target instanceof Schema)) {
         return undefined;

--- a/modules/core/test/range.spec.ts
+++ b/modules/core/test/range.spec.ts
@@ -1,6 +1,6 @@
-import { getRange, range, rangeSchema } from '../src/range';
+import { getRange, range, rangeSchema, tryGetRange } from '../src/range';
 import { JsonPointer } from '../src/json-ptr';
-import { Schema } from '@colyseus/schema';
+import { ArraySchema, MapSchema, Schema } from '@colyseus/schema';
 import { expect } from 'chai';
 import { gameField } from '../src/game-field';
 
@@ -67,5 +67,46 @@ describe('range', () => {
 
         const r = getRange(new Target(), JsonPointer.create('/property'));
         expect(r).to.eql(RANGE);
+    });
+});
+
+describe('ArraySchema JSON pointer support', () => {
+    class Inner extends Schema {
+        @gameField(['uint8'])
+        levels = new ArraySchema<number>(0, 0);
+    }
+
+    class Root extends Schema {
+        @gameField({ map: Inner })
+        items = new MapSchema<Inner>();
+    }
+
+    function makeRoot() {
+        const root = new Root();
+        const inner = new Inner();
+        root.items.set('obj1', inner);
+        return root;
+    }
+
+    it('tryGetRange does not throw for ArraySchema element path', () => {
+        const root = makeRoot();
+        const pointer = JsonPointer.create('/items/obj1/levels/0');
+        // Should return undefined (no range metadata on array elements), not throw
+        const result = tryGetRange(root, pointer);
+        expect(result).to.be.undefined;
+    });
+
+    it('JsonPointer.set can set values on ArraySchema elements', () => {
+        const root = makeRoot();
+        const pointer = JsonPointer.create('/items/obj1/levels/0');
+        pointer.set(root, 1);
+        expect(root.items.get('obj1')!.levels[0]).to.equal(1);
+    });
+
+    it('JsonPointer.get can read values from ArraySchema elements', () => {
+        const root = makeRoot();
+        root.items.get('obj1')!.levels[0] = 2;
+        const pointer = JsonPointer.create('/items/obj1/levels/0');
+        expect(pointer.get(root)).to.equal(2);
     });
 });

--- a/modules/core/test/range.spec.ts
+++ b/modules/core/test/range.spec.ts
@@ -1,6 +1,6 @@
+import { ArraySchema, MapSchema, Schema } from '@colyseus/schema';
 import { getRange, range, rangeSchema, tryGetRange } from '../src/range';
 import { JsonPointer } from '../src/json-ptr';
-import { ArraySchema, MapSchema, Schema } from '@colyseus/schema';
 import { expect } from 'chai';
 import { gameField } from '../src/game-field';
 
@@ -93,7 +93,7 @@ describe('ArraySchema JSON pointer support', () => {
         const pointer = JsonPointer.create('/items/obj1/levels/0');
         // Should return undefined (no range metadata on array elements), not throw
         const result = tryGetRange(root, pointer);
-        expect(result).to.be.undefined;
+        expect(result).to.equal(undefined);
     });
 
     it('JsonPointer.set can set values on ArraySchema elements', () => {


### PR DESCRIPTION
## Summary

- Implements scan level visibility gating for radar blips — unidentified objects (scan level below BASIC) display with limited information and a distinct dim gray tint
- Adds ArraySchema support to JSON pointer and range utilities for accessing scan level data
- Propagates player faction through all radar widget instantiations to ObjectsLayer

## MUST fill in (do not delete this section)

State sync invariants:

- [x] I did NOT write directly to `*.state.position`, `*.state.velocity`,
      `*.state.angle`, `*.state.turnSpeed`, or `*.state.health` outside
      `syncShipProperties` (`modules/core/src/ship/ship-manager-abstract.ts`)
      or `space-manager.ts`. If I did, I have justified it below.

`@gameField` decorator order:

- [x] Any new `@gameField` is the INNERMOST decorator (declared LAST, below
      `@tweakable`, `@range`, etc.). Decorator order is enforced by lint;
      see `docs/PATTERNS.md`.

Remote command surface:

- [x] Any property a client must remotely write satisfies one of four
      admission clauses: `@commandable()` (leaf), `@commandable({ '/x': true })`
      on a parent property (nested Schema descendant), `@tweakable` (GM tweak
      panel), or `DesignState` subclass (GM design-state panel). Bare
      `@gameField`s outside those clauses are **always rejected** (no
      warn-only mode). See `docs/json-ptr.md`.

Public API:

- [x] I did NOT add new exports to `modules/core/src/index.public.ts`
      without explicit reviewer approval. Internal symbols belong in
      `index.internal.ts` and are imported via `@starwards/core/internal`.

Local verification:

- [x] I ran `npm run test:static && npm test` locally and they pass.
- [x] If I touched a station screen, I ran the relevant E2E spec under
      `modules/e2e/test/` locally.

Skill / docs hygiene:

- [x] If I changed behavior documented in `.claude/skills/` or `docs/`,
      I updated the relevant skill / doc in the same PR.
- [x] No new top-level singletons, unbounded caches, or globally mutable
      module state were introduced.

## Hotspot files touched

- `modules/core/src/json-ptr.ts` — added ArraySchema element access in `set()`
- `modules/core/src/range.ts` — added ArraySchema traversal in `getParent()` and `tryGetRange()`

## Tests added or updated

- `modules/core/test/range.spec.ts` — added `ArraySchema JSON pointer support` test suite (3 tests)

## Skills reviewed

- none

https://claude.ai/code/session_01C9GrUQXf53Zf1kLupYXKY8