### PR TITLE
Add preview deploy pipeline to K3s cluster

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,8 +7,8 @@ docker/
 models/
 node_modules/
 psd/
-scripts/
 test-results/
 
 modules/**/node_modules/
 modules/**/cjs
+modules/e2e/

--- a/.github/k8s/template.yaml
+++ b/.github/k8s/template.yaml
@@ -1,0 +1,97 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starwards-${RELEASE}
+  namespace: starwards
+  labels:
+    app: starwards
+    release: ${RELEASE}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: starwards
+      release: ${RELEASE}
+  template:
+    metadata:
+      labels:
+        app: starwards
+        release: ${RELEASE}
+    spec:
+      containers:
+        - name: starwards
+          image: ${IMAGE}
+          ports:
+            - containerPort: 80
+          env:
+            - name: PORT
+              value: "80"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: starwards-${RELEASE}
+  namespace: starwards
+  labels:
+    app: starwards
+    release: ${RELEASE}
+spec:
+  selector:
+    app: starwards
+    release: ${RELEASE}
+  ports:
+    - port: 80
+      targetPort: 80
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: starwards-${RELEASE}
+  namespace: starwards
+  labels:
+    app: starwards
+    release: ${RELEASE}
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`${HOST}`)
+      kind: Rule
+      services:
+        - name: starwards-${RELEASE}
+          port: 80
+  tls:
+    secretName: wildcard-starwards-tls
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: starwards-${RELEASE}-redirect
+  namespace: starwards
+  labels:
+    app: starwards
+    release: ${RELEASE}
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: Host(`${HOST}`)
+      kind: Rule
+      middlewares:
+        - name: redirect-https
+      services:
+        - name: starwards-${RELEASE}
+          port: 80

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,131 @@
+name: Deploy Preview
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+concurrency:
+  group: deploy-${{ github.event.pull_request.number || 'master' }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: ghcr.io/${{ github.repository }}
+  BASE_DOMAIN: dev.starwards.space
+
+jobs:
+  build-push:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      release: ${{ steps.meta.outputs.release }}
+      host: ${{ steps.meta.outputs.host }}
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: meta
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            RELEASE="pr-${{ github.event.pull_request.number }}"
+          else
+            RELEASE="master"
+          fi
+          echo "release=${RELEASE}" >> "$GITHUB_OUTPUT"
+          echo "host=${RELEASE}.${BASE_DOMAIN}" >> "$GITHUB_OUTPUT"
+          echo "image=${IMAGE}:${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.image }}
+            ${{ env.IMAGE }}:${{ steps.meta.outputs.release }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    needs: build-push
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: tailscale/github-action@v3
+        with:
+          authkey: ${{ secrets.TS_AUTH_KEY }}
+
+      - name: Install kubectl
+        run: |
+          curl -LO "https://dl.k8s.io/release/$(curl -Ls https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          chmod +x kubectl
+          sudo mv kubectl /usr/local/bin/
+
+      - name: Deploy to cluster
+        env:
+          RELEASE: ${{ needs.build-push.outputs.release }}
+          HOST: ${{ needs.build-push.outputs.host }}
+          IMAGE: ${{ needs.build-push.outputs.image }}
+        run: |
+          echo '${{ secrets.KUBECONFIG }}' > /tmp/kubeconfig
+          export KUBECONFIG=/tmp/kubeconfig
+          envsubst < .github/k8s/template.yaml | kubectl apply -f -
+          kubectl -n starwards rollout status deployment/starwards-${RELEASE} --timeout=180s
+
+      - name: Comment preview URL
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request.number;
+            const url = `https://pr-${pr}.${{ env.BASE_DOMAIN }}`;
+            const body = `🎮 Preview deployed: ${url}`;
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo, issue_number: pr
+            });
+            const existing = comments.find(c => c.body.includes('Preview deployed:'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...context.repo, comment_id: existing.id, body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number: pr, body
+              });
+            }
+
+  teardown:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tailscale/github-action@v3
+        with:
+          authkey: ${{ secrets.TS_AUTH_KEY }}
+
+      - name: Install kubectl
+        run: |
+          curl -LO "https://dl.k8s.io/release/$(curl -Ls https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          chmod +x kubectl
+          sudo mv kubectl /usr/local/bin/
+
+      - name: Delete preview environment
+        run: |
+          echo '${{ secrets.KUBECONFIG }}' > /tmp/kubeconfig
+          export KUBECONFIG=/tmp/kubeconfig
+          kubectl -n starwards delete deployment,svc,ingressroute \
+            -l app=starwards,release=pr-${{ github.event.pull_request.number }} \
+            --ignore-not-found

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:22-bookworm AS build
+WORKDIR /app
+COPY . .
+RUN npm ci
+RUN npm run build
+# postbuild runs automatically: modules pack → post-build.js assembles dist/
+RUN cd dist && npm install --omit=dev
+
+FROM node:22-bookworm-slim
+WORKDIR /app
+COPY --from=build /app/dist/ ./
+ENV PORT=80
+EXPOSE 80
+CMD ["node", "node_modules/@starwards/server/cjs/prod.js"]


### PR DESCRIPTION
## Summary

- Add Dockerfile for multi-stage production build (node:22, port 80)
- Add GitHub Actions workflow: build+push to GHCR, deploy to K3s via Tailscale, teardown on PR close
- Add K8s manifest template using Traefik IngressRoute CRDs
- Update .dockerignore to include `scripts/` (needed for post-build) and exclude `modules/e2e/`

Preview URLs: `pr-<N>.dev.starwards.space` (PRs), `master.dev.starwards.space` (master)

## MUST fill in (do not delete this section)

State sync invariants:

- [x] I did NOT write directly to `*.state.position`, `*.state.velocity`,
      `*.state.angle`, `*.state.turnSpeed`, or `*.state.health` outside
      `syncShipProperties` (`modules/core/src/ship/ship-manager-abstract.ts`)
      or `space-manager.ts`. If I did, I have justified it below.

`@gameField` decorator order:

- [x] Any new `@gameField` is the INNERMOST decorator (declared LAST, below
      `@tweakable`, `@range`, etc.). Decorator order is enforced by lint;
      see `docs/PATTERNS.md`.

Remote command surface:

- [x] Any property a client must remotely write satisfies one of four
      admission clauses: `@commandable()` (leaf), `@commandable({ '/x': true })`
      on a parent property (nested Schema descendant), `@tweakable` (GM tweak
      panel), or `DesignState` subclass (GM design-state panel). Bare
      `@gameField`s outside those clauses are **always rejected** (no
      warn-only mode). See `docs/json-ptr.md`.

Public API:

- [x] I did NOT add new exports to `modules/core/src/index.public.ts`
      without explicit reviewer approval. Internal symbols belong in
      `index.internal.ts` and are imported via `@starwards/core/internal`.

Local verification:

- [x] I ran `npm run test:static && npm test` locally and they pass.
- [x] If I touched a station screen, I ran the relevant E2E spec under
      `modules/e2e/test/` locally.

Skill / docs hygiene:

- [x] If I changed behavior documented in `.claude/skills/` or `docs/`,
      I updated the relevant skill / doc in the same PR.
- [x] No new top-level singletons, unbounded caches, or globally mutable
      module state were introduced.

N/A — this PR only adds CI/CD infrastructure files (Dockerfile, workflow, K8s template, .dockerignore). No game code was modified.

## Hotspot files touched

none

## Tests added or updated

none — CI/CD infrastructure only, tested by the pipeline itself

## Skills reviewed

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)