### PR TITLE
Add hotkey help display to signals screen

### DIFF
--- a/modules/browser/src/screens/signals.ts
+++ b/modules/browser/src/screens/signals.ts
@@ -8,6 +8,7 @@ import ElementQueries from 'css-element-queries/src/ElementQueries';
 import EventEmitter from 'eventemitter3';
 import { InputManager } from '../input/input-manager';
 import { SelectionContainer } from '../radar/selection-container';
+import { setupHotkeyHelp } from '../input/hotkey-help';
 import { drawLongRangeRadar } from '../widgets/long-range-radar';
 import { drawSystemsStatus } from '../widgets/system-status';
 import { drawTargetInfo } from '../widgets/target-info';
@@ -89,13 +90,14 @@ function wireInput(
     }
 
     const input = new InputManager();
-    input.addClickAction(() => cycleTarget(1), ']');
-    input.addClickAction(() => cycleTarget(-1), '[');
+    input.addClickAction(() => cycleTarget(1), ']', 'Next Target');
+    input.addClickAction(() => cycleTarget(-1), '[', 'Prev Target');
     input.addClickAction(() => {
         stationTarget.clear();
         currentIndex = -1;
-    }, "'");
-    input.addClickAction(() => zoomEvents.emit('zoomIn'), '=');
-    input.addClickAction(() => zoomEvents.emit('zoomOut'), '-');
+    }, "'", 'Clear Target');
+    input.addClickAction(() => zoomEvents.emit('zoomIn'), '=', 'Zoom In');
+    input.addClickAction(() => zoomEvents.emit('zoomOut'), '-', 'Zoom Out');
     input.init();
+    setupHotkeyHelp(input);
 }


### PR DESCRIPTION
## Summary

- Added hotkey help functionality to the signals screen by importing and initializing `setupHotkeyHelp`
- Enhanced input action definitions with human-readable labels for all hotkeys (Next Target, Prev Target, Clear Target, Zoom In, Zoom Out)
- Updated `InputManager.addClickAction()` calls to include descriptive labels as a third parameter

## MUST fill in (do not delete this section)

State sync invariants:

- [x] I did NOT write directly to `*.state.position`, `*.state.velocity`,
      `*.state.angle`, `*.state.turnSpeed`, or `*.state.health` outside
      `syncShipProperties` or `space-manager.ts`. Not applicable to this change.

`@gameField` decorator order:

- [x] Any new `@gameField` is the INNERMOST decorator. Not applicable to this change.

Remote command surface:

- [x] Any property a client must remotely write satisfies one of four
      admission clauses. Not applicable to this change.

Public API:

- [x] I did NOT add new exports to `modules/core/src/index.public.ts`
      without explicit reviewer approval. Not applicable to this change.

Local verification:

- [x] I ran `npm run test:static && npm test` locally and they pass.
- [x] If I touched a station screen, I ran the relevant E2E spec under
      `modules/e2e/test/` locally. Signals screen E2E tests pass.

Skill / docs hygiene:

- [x] If I changed behavior documented in `.claude/skills/` or `docs/`,
      I updated the relevant skill / doc in the same PR. Not applicable.
- [x] No new top-level singletons, unbounded caches, or globally mutable
      module state were introduced.

## Hotspot files touched

None

## Tests added or updated

None. This change integrates existing hotkey help infrastructure with the signals screen input system.

## Skills reviewed

None

https://claude.ai/code/session_01E2cMRtyqpD9zWYfu8SYVjj