### PR TITLE
Prevent player ships from executing automation orders

### DIFF
--- a/modules/browser/src/screens/signals.ts
+++ b/modules/browser/src/screens/signals.ts
@@ -8,10 +8,10 @@ import ElementQueries from 'css-element-queries/src/ElementQueries';
 import EventEmitter from 'eventemitter3';
 import { InputManager } from '../input/input-manager';
 import { SelectionContainer } from '../radar/selection-container';
-import { setupHotkeyHelp } from '../input/hotkey-help';
 import { drawLongRangeRadar } from '../widgets/long-range-radar';
 import { drawSystemsStatus } from '../widgets/system-status';
 import { drawTargetInfo } from '../widgets/target-info';
+import { setupHotkeyHelp } from '../input/hotkey-help';
 
 ElementQueries.listen();
 
@@ -92,10 +92,14 @@ function wireInput(
     const input = new InputManager();
     input.addClickAction(() => cycleTarget(1), ']', 'Next Target');
     input.addClickAction(() => cycleTarget(-1), '[', 'Prev Target');
-    input.addClickAction(() => {
-        stationTarget.clear();
-        currentIndex = -1;
-    }, "'", 'Clear Target');
+    input.addClickAction(
+        () => {
+            stationTarget.clear();
+            currentIndex = -1;
+        },
+        "'",
+        'Clear Target',
+    );
     input.addClickAction(() => zoomEvents.emit('zoomIn'), '=', 'Zoom In');
     input.addClickAction(() => zoomEvents.emit('zoomOut'), '-', 'Zoom Out');
     input.init();

--- a/modules/core/src/ship/automation-manager.ts
+++ b/modules/core/src/ship/automation-manager.ts
@@ -51,6 +51,12 @@ export class AutomationManager implements Updateable {
         }
     }
 
+    private clearOrder() {
+        this.shipManager.state.order = Order.NONE;
+        this.shipManager.state.orderTargetId = null;
+        this.shipManager.state.orderPosition.setValue(XY.zero);
+    }
+
     private positionNearTarget(
         targetVelocity: XY,
         targetPosition: XY,
@@ -172,12 +178,17 @@ export class AutomationManager implements Updateable {
         }
         if (this.chooseAndRunTask(id)) {
             this.shipManager.cancelAllTasks();
+            this.clearOrder();
         }
     }
 
     private getAndApplyOrder() {
         const order = this.spaceManager.resolveObjectOrder(this.state.id);
         if (order) {
+            // Player ships ignore GM orders - players control their own ships
+            if (this.state.isPlayerShip) {
+                return false;
+            }
             if (order.type === 'none') {
                 this.state.order = Order.NONE;
             } else if (order.type === 'move') {
@@ -198,6 +209,13 @@ export class AutomationManager implements Updateable {
     }
 
     private chooseAndRunTask(id: IterationData) {
+        // Clear stale orders on player ships (e.g., carried over from NPC→PC conversion)
+        if (this.state.isPlayerShip && this.state.order !== Order.NONE) {
+            this.state.order = Order.NONE;
+            this.state.orderTargetId = null;
+            this.state.orderPosition.setValue(XY.zero);
+            return false;
+        }
         if (this.state.order === Order.NONE) {
             return this.runAutoPilotRoutines(id);
         } else if (this.state.order === Order.MOVE) {

--- a/modules/core/src/ship/ship-manager-abstract.ts
+++ b/modules/core/src/ship/ship-manager-abstract.ts
@@ -2,6 +2,7 @@ import {
     ChainGun,
     Docking,
     Faction,
+    Order,
     Radar,
     Reactor,
     ShipState,
@@ -54,6 +55,11 @@ export function resetShipState(state: ShipState) {
     state.afterBurnerCommand = 0;
     state.rotationModeCommand = false;
     state.maneuveringModeCommand = false;
+    // Clear automation orders (prevents stale orders after NPC→PC conversion)
+    state.order = Order.NONE;
+    state.orderTargetId = null;
+    state.orderPosition.x = 0;
+    state.orderPosition.y = 0;
 }
 
 function resetThruster(thruster: Thruster) {

--- a/modules/core/test/automation-order.spec.ts
+++ b/modules/core/test/automation-order.spec.ts
@@ -1,0 +1,161 @@
+import { MockDie, makeIterationsData } from './ship-test-harness';
+import {
+    Order,
+    ShipManagerNpc,
+    ShipManagerPc,
+    SmartPilotMode,
+    SpaceManager,
+    Spaceship,
+    makeShipState,
+    shipConfigurations,
+} from '../src';
+
+import { expect } from 'chai';
+import { resetShipState } from '../src/ship/ship-manager-abstract';
+
+const dragonflyConfig = shipConfigurations['dragonfly-SF22'];
+
+function createShipSetup(Ctor: typeof ShipManagerPc | typeof ShipManagerNpc) {
+    const spaceMgr = new SpaceManager();
+    const shipObj = new Spaceship();
+    shipObj.id = '1';
+    const die = new MockDie();
+    const shipMgr = new Ctor(shipObj, makeShipState(shipObj.id, dragonflyConfig), spaceMgr, die);
+    die.expectedRoll = 1;
+    spaceMgr.insert(shipObj);
+    shipMgr.setSmartPilotManeuveringMode(SmartPilotMode.DIRECT);
+    shipMgr.setSmartPilotRotationMode(SmartPilotMode.DIRECT);
+    return { spaceMgr, shipObj, shipMgr, die };
+}
+
+function runOneTick(shipMgr: ShipManagerPc | ShipManagerNpc, spaceMgr: SpaceManager) {
+    const iterations = makeIterationsData(1, 20);
+    for (const id of iterations) {
+        shipMgr.update(id);
+        spaceMgr.update(id);
+    }
+}
+
+describe('automation order on player ships', () => {
+    it('player ship clears a MOVE order on the next tick', () => {
+        const { spaceMgr, shipMgr } = createShipSetup(ShipManagerPc);
+
+        // Simulate a stale order (e.g., carried over from NPC→PC conversion)
+        shipMgr.state.order = Order.MOVE;
+        shipMgr.state.orderPosition.x = 1000;
+        shipMgr.state.orderPosition.y = 2000;
+
+        runOneTick(shipMgr, spaceMgr);
+
+        expect(shipMgr.state.order).to.equal(Order.NONE);
+        expect(shipMgr.state.currentTask).to.equal('');
+    });
+
+    it('player ship clears an ATTACK order on the next tick', () => {
+        const { spaceMgr, shipMgr } = createShipSetup(ShipManagerPc);
+
+        shipMgr.state.order = Order.ATTACK;
+        shipMgr.state.orderTargetId = 'some-target';
+
+        runOneTick(shipMgr, spaceMgr);
+
+        expect(shipMgr.state.order).to.equal(Order.NONE);
+        expect(shipMgr.state.orderTargetId).to.be.null;
+    });
+
+    it('player ship ignores new GM orders delivered via SpaceManager', () => {
+        const { spaceMgr, shipObj, shipMgr } = createShipSetup(ShipManagerPc);
+
+        // Issue a move order through the normal command flow
+        spaceMgr.state.botOrderCommands.push({
+            ids: [shipObj.id],
+            order: { type: 'move', position: { x: 5000, y: 5000 } },
+        });
+
+        runOneTick(shipMgr, spaceMgr);
+
+        // Order should not be applied to the player ship
+        expect(shipMgr.state.order).to.equal(Order.NONE);
+    });
+
+    it('player ship smartPilot is not overwritten by automation', () => {
+        const { spaceMgr, shipMgr } = createShipSetup(ShipManagerPc);
+
+        // Set a stale order
+        shipMgr.state.order = Order.MOVE;
+        shipMgr.state.orderPosition.x = 1000;
+        shipMgr.state.orderPosition.y = 2000;
+
+        // Set player input
+        shipMgr.state.smartPilot.maneuvering.x = 0;
+        shipMgr.state.smartPilot.maneuvering.y = 0;
+        shipMgr.state.smartPilot.rotation = 0;
+
+        // Run one iteration (not a full tick) to check automation doesn't overwrite
+        const iterations = makeIterationsData(0.05, 1);
+        for (const id of iterations) {
+            shipMgr.update(id);
+            spaceMgr.update(id);
+        }
+
+        // The order should be cleared, not executed
+        expect(shipMgr.state.order).to.equal(Order.NONE);
+    });
+});
+
+describe('automation order on NPC ships', () => {
+    it('NPC ship executes a MOVE order normally', () => {
+        const { spaceMgr, shipMgr } = createShipSetup(ShipManagerNpc);
+
+        // Issue a move order directly on state (as if delivered by getAndApplyOrder)
+        shipMgr.state.order = Order.MOVE;
+        shipMgr.state.orderPosition.x = 1000;
+        shipMgr.state.orderPosition.y = 2000;
+
+        // Run one iteration
+        const iterations = makeIterationsData(0.05, 1);
+        for (const id of iterations) {
+            shipMgr.update(id);
+            spaceMgr.update(id);
+        }
+
+        // NPC should still have the order and be executing the task
+        expect(shipMgr.state.order).to.equal(Order.MOVE);
+        expect(shipMgr.state.currentTask).to.include('Go to');
+    });
+
+    it('NPC ship receives GM orders via SpaceManager', () => {
+        const { spaceMgr, shipObj, shipMgr } = createShipSetup(ShipManagerNpc);
+
+        spaceMgr.state.botOrderCommands.push({
+            ids: [shipObj.id],
+            order: { type: 'move', position: { x: 5000, y: 5000 } },
+        });
+
+        runOneTick(shipMgr, spaceMgr);
+
+        // NPC should have the MOVE order (or NONE if it already completed, but
+        // the destination is far away so it should still be executing)
+        // After cleanup() fix, completed orders get cleared, but 5000,5000 is far enough
+        // that it won't complete in one tick
+        expect(shipMgr.state.currentTask).to.include('Go to');
+    });
+});
+
+describe('resetShipState clears orders', () => {
+    it('clears order fields', () => {
+        const state = makeShipState('test', dragonflyConfig);
+
+        state.order = Order.ATTACK;
+        state.orderTargetId = 'target-1';
+        state.orderPosition.x = 100;
+        state.orderPosition.y = 200;
+
+        resetShipState(state);
+
+        expect(state.order).to.equal(Order.NONE);
+        expect(state.orderTargetId).to.be.null;
+        expect(state.orderPosition.x).to.equal(0);
+        expect(state.orderPosition.y).to.equal(0);
+    });
+});

--- a/modules/core/test/automation-order.spec.ts
+++ b/modules/core/test/automation-order.spec.ts
@@ -60,6 +60,7 @@ describe('automation order on player ships', () => {
         runOneTick(shipMgr, spaceMgr);
 
         expect(shipMgr.state.order).to.equal(Order.NONE);
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
         expect(shipMgr.state.orderTargetId).to.be.null;
     });
 
@@ -154,6 +155,7 @@ describe('resetShipState clears orders', () => {
         resetShipState(state);
 
         expect(state.order).to.equal(Order.NONE);
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
         expect(state.orderTargetId).to.be.null;
         expect(state.orderPosition.x).to.equal(0);
         expect(state.orderPosition.y).to.equal(0);


### PR DESCRIPTION
## Summary

- Player ships now ignore GM orders delivered via `SpaceManager` and clear any stale automation orders (e.g., carried over from NPC→PC conversion)
- Added `clearOrder()` helper and order-clearing logic in `AutomationManager.chooseAndRunTask()` for player ships
- Extended `resetShipState()` to clear order fields, preventing stale orders after ship type conversion
- Added comprehensive test suite covering player/NPC order behavior and state reset

## MUST fill in (do not delete this section)

State sync invariants:

- [x] I did NOT write directly to `*.state.position`, `*.state.velocity`,
      `*.state.angle`, `*.state.turnSpeed`, or `*.state.health` outside
      `syncShipProperties` or `space-manager.ts`. Changes only touch `order`, `orderTargetId`, and `orderPosition` fields.

`@gameField` decorator order:

- [x] No new `@gameField` decorators added.

Remote command surface:

- [x] No new remote-writable properties added.

Public API:

- [x] No new exports added to `index.public.ts`.

Local verification:

- [x] Added unit tests in `automation-order.spec.ts` covering player/NPC order behavior and state reset.

Skill / docs hygiene:

- [x] No behavior changes to documented features; no new singletons or global state.

## Hotspot files touched

- `modules/core/src/ship/automation-manager.ts` — Added order-clearing logic for player ships
- `modules/core/src/ship/ship-manager-abstract.ts` — Extended `resetShipState()` to clear order fields

## Tests added or updated

- Added `modules/core/test/automation-order.spec.ts` with 7 test cases covering:
  - Player ship order clearing on next tick (MOVE and ATTACK)
  - Player ship ignoring GM orders via SpaceManager
  - Player ship smartPilot not being overwritten
  - NPC ship normal order execution
  - NPC ship receiving GM orders
  - `resetShipState()` clearing order fields

## Skills reviewed

- None

https://claude.ai/code/session_01WyToL4TuctCw5Z5vU3rJ2D