### PR TITLE
fix: clean up ship rooms and managers when game stops (closes #748)

### DIFF
--- a/modules/server/src/admin/game-manager.ts
+++ b/modules/server/src/admin/game-manager.ts
@@ -86,18 +86,21 @@ export class GameManager {
         this.map = null;
         if (this.state.gameStatus === GameStatus.RUNNING) {
             this.state.gameStatus = GameStatus.STOPPING;
-            this.state.playerShipIds.splice(0);
-            this.state.shipIds.splice(0);
-            const shipRooms = await matchMaker.query({ name: 'ship' });
-            for (const shipRoom of shipRooms) {
-                await matchMaker.remoteRoomCall(shipRoom.roomId, 'disconnect', []);
-            }
+            // Use registered ship cleanup functions which await pending
+            // room creation before disconnecting, preventing race conditions
+            // where matchMaker.query() could miss rooms still being created.
+            const cleanups = [...this.shipCleanups.values()];
+            await Promise.allSettled(cleanups.map((cleanup) => cleanup()));
             const spaceRooms = await matchMaker.query({ name: 'space' });
             for (const spaceRoom of spaceRooms) {
                 await matchMaker.remoteRoomCall(spaceRoom.roomId, 'disconnect', []);
             }
+            // Clear all remaining state
+            this.state.playerShipIds.splice(0);
+            this.state.shipIds.splice(0);
             this.dice = [];
             this.shipCleanups.clear();
+            this.shipManagers.clear();
             this.convertingShips.clear();
             this.state.gameStatus = GameStatus.STOPPED;
         }


### PR DESCRIPTION
Closes #748

## Summary

- **Fixed race condition**: `stopGame()` previously used `matchMaker.query({ name: 'ship' })` to find rooms to disconnect, but this could miss rooms still being created asynchronously. Now uses the registered per-ship cleanup functions which properly `await` pending room creation before disconnecting.
- **Added error resilience**: Uses `Promise.allSettled()` so a failure cleaning up one ship doesn't prevent cleanup of others.
- **Fixed memory leak**: Added missing `shipManagers.clear()` — ship manager references were never released between game sessions.

## MUST fill in (do not delete this section)

State sync invariants:

- [x] I did NOT write directly to `*.state.position`, `*.state.velocity`,
      `*.state.angle`, `*.state.turnSpeed`, or `*.state.health` outside
      `syncShipProperties` (`modules/core/src/ship/ship-manager-abstract.ts`)
      or `space-manager.ts`. If I did, I have justified it below.

`@gameField` decorator order:

- [x] Any new `@gameField` is the INNERMOST decorator (declared LAST, below
      `@tweakable`, `@range`, etc.). Decorator order is enforced by lint;
      see `docs/PATTERNS.md`.

Remote command surface:

- [x] Any property a client must remotely write satisfies one of four
      admission clauses: `@commandable()` (leaf), `@commandable({ '/x': true })`
      on a parent property (nested Schema descendant), `@tweakable` (GM tweak
      panel), or `DesignState` subclass (GM design-state panel). Bare
      `@gameField`s outside those clauses are **always rejected** (no
      warn-only mode). See `docs/json-ptr.md`.

Public API:

- [x] I did NOT add new exports to `modules/core/src/index.public.ts`
      without explicit reviewer approval. Internal symbols belong in
      `index.internal.ts` and are imported via `@starwards/core/internal`.

Local verification:

- [x] I ran `npm run test:static && npm test` locally and they pass.
- [x] If I touched a station screen, I ran the relevant E2E spec under
      `modules/e2e/test/` locally.

Skill / docs hygiene:

- [x] If I changed behavior documented in `.claude/skills/` or `docs/`,
      I updated the relevant skill / doc in the same PR.
- [x] No new top-level singletons, unbounded caches, or globally mutable
      module state were introduced.

## Hotspot files touched

none

## Tests added or updated

none — the existing `server-api.spec.ts` test for start/stop game continues to pass and validates the fix. No new state sync, decorator, or command surface was introduced.

## Skills reviewed

none

🤖 Automated by Claude Code