### PR TITLE
fix: align getVelocityCapacity with actual thruster physics (closes #805)

### DIFF
--- a/modules/core/src/ship/thruster.ts
+++ b/modules/core/src/ship/thruster.ts
@@ -78,6 +78,12 @@ export class Thruster extends SystemState {
         return this.angle + parent.angle;
     }
     getVelocityCapacity(parent: ShipState): number {
-        return this.effectiveness * (this.design.capacity + parent.afterBurner * this.design.afterBurnerCapacity);
+        const mvCapacity = this.design.capacity;
+        const abCapacity =
+            parent.afterBurner *
+            this.design.afterBurnerCapacity *
+            parent.maneuvering.effectiveness *
+            parent.maneuvering.efficiency;
+        return this.effectiveness * this.availableCapacity * (mvCapacity + abCapacity);
     }
 }

--- a/modules/core/test/thruster-ship-integration.spec.ts
+++ b/modules/core/test/thruster-ship-integration.spec.ts
@@ -54,6 +54,27 @@ describe('thrusters-ship integration', function () {
                 }),
             );
         });
+
+        it(`(FWD only) scales with partial availableCapacity`, () => {
+            const direction = ShipDirection.FWD;
+            fc.assert(
+                fc.property(float(0, 0.5), float(0.1, 0.9), (afterBurner: number, partialCapacity: number) => {
+                    const fullHarness = new ShipTestHarness();
+                    fullHarness.shipState.afterBurner = fullHarness.shipState.afterBurnerCommand = afterBurner;
+                    const fullCapacity = fullHarness.shipState.velocityCapacity(direction);
+
+                    const partialHarness = new ShipTestHarness();
+                    partialHarness.shipState.afterBurner = partialHarness.shipState.afterBurnerCommand = afterBurner;
+                    for (const thruster of partialHarness.shipState.angleThrusters(direction)) {
+                        thruster.availableCapacity = partialCapacity;
+                    }
+                    expect(
+                        partialHarness.shipState.velocityCapacity(direction),
+                        'partial capacity scales linearly',
+                    ).to.be.closeTo(fullCapacity * partialCapacity, EPSILON);
+                }),
+            );
+        });
     });
 
     it(`(FWD only) broken thruster does not work`, () => {


### PR DESCRIPTION
Closes #805

## Summary
- Added `availableCapacity` factor to `Thruster.getVelocityCapacity()` — partial thruster damage now correctly reduces the capacity estimate, matching the actual physics in `updateVelocityFromThrusters()`
- Added `maneuvering.effectiveness * maneuvering.efficiency` to the afterburner portion of the capacity calculation, mirroring how afterburner velocity is actually computed
- Added property-based test verifying that `velocityCapacity` scales linearly with partial `availableCapacity`

## MUST fill in (do not delete this section)

State sync invariants:

- [x] I did NOT write directly to `*.state.position`, `*.state.velocity`,
      `*.state.angle`, `*.state.turnSpeed`, or `*.state.health` outside
      `syncShipProperties` (`modules/core/src/ship/ship-manager-abstract.ts`)
      or `space-manager.ts`. If I did, I have justified it below.

`@gameField` decorator order:

- [x] Any new `@gameField` is the INNERMOST decorator (declared LAST, below
      `@tweakable`, `@range`, etc.). Decorator order is enforced by lint;
      see `docs/PATTERNS.md`.

Remote command surface:

- [x] Any property a client must remotely write satisfies one of four
      admission clauses: `@commandable()` (leaf), `@commandable({ '/x': true })`
      on a parent property (nested Schema descendant), `@tweakable` (GM tweak
      panel), or `DesignState` subclass (GM design-state panel). Bare
      `@gameField`s outside those clauses are **always rejected** (no
      warn-only mode). See `docs/json-ptr.md`.

Public API:

- [x] I did NOT add new exports to `modules/core/src/index.public.ts`
      without explicit reviewer approval. Internal symbols belong in
      `index.internal.ts` and are imported via `@starwards/core/internal`.

Local verification:

- [x] I ran `npm run test:static && npm test` locally and they pass.
- [x] If I touched a station screen, I ran the relevant E2E spec under
      `modules/e2e/test/` locally.

Skill / docs hygiene:

- [x] If I changed behavior documented in `.claude/skills/` or `docs/`,
      I updated the relevant skill / doc in the same PR.
- [x] No new top-level singletons, unbounded caches, or globally mutable
      module state were introduced.

## Hotspot files touched

none

## Tests added or updated

- `modules/core/test/thruster-ship-integration.spec.ts` — new property-based test: `(FWD only) scales with partial availableCapacity`

## Skills reviewed

- `starwards-colyseus`

🤖 Automated by Claude Code