### PR TITLE
Refactor: Organize imports and format hotkey action in signals

### DIFF
--- a/modules/browser/src/screens/signals.ts
+++ b/modules/browser/src/screens/signals.ts
@@ -8,10 +8,10 @@ import ElementQueries from 'css-element-queries/src/ElementQueries';
 import EventEmitter from 'eventemitter3';
 import { InputManager } from '../input/input-manager';
 import { SelectionContainer } from '../radar/selection-container';
-import { setupHotkeyHelp } from '../input/hotkey-help';
 import { drawLongRangeRadar } from '../widgets/long-range-radar';
 import { drawSystemsStatus } from '../widgets/system-status';
 import { drawTargetInfo } from '../widgets/target-info';
+import { setupHotkeyHelp } from '../input/hotkey-help';
 
 ElementQueries.listen();
 
@@ -92,10 +92,14 @@ function wireInput(
     const input = new InputManager();
     input.addClickAction(() => cycleTarget(1), ']', 'Next Target');
     input.addClickAction(() => cycleTarget(-1), '[', 'Prev Target');
-    input.addClickAction(() => {
-        stationTarget.clear();
-        currentIndex = -1;
-    }, "'", 'Clear Target');
+    input.addClickAction(
+        () => {
+            stationTarget.clear();
+            currentIndex = -1;
+        },
+        "'",
+        'Clear Target',
+    );
     input.addClickAction(() => zoomEvents.emit('zoomIn'), '=', 'Zoom In');
     input.addClickAction(() => zoomEvents.emit('zoomOut'), '-', 'Zoom Out');
     input.init();


### PR DESCRIPTION
## Summary

- Reorganized imports in `modules/browser/src/screens/signals.ts` to follow alphabetical order (moved `setupHotkeyHelp` import after widget imports)
- Reformatted the "Clear Target" hotkey action callback to use consistent multi-line formatting with trailing comma

## MUST fill in (do not delete this section)

State sync invariants:

- [x] I did NOT write directly to `*.state.position`, `*.state.velocity`,
      `*.state.angle`, `*.state.turnSpeed`, or `*.state.health` outside
      `syncShipProperties` or `space-manager.ts`. Not applicable to this change.

`@gameField` decorator order:

- [x] Any new `@gameField` is the INNERMOST decorator. Not applicable to this change.

Remote command surface:

- [x] Any property a client must remotely write satisfies admission clauses. Not applicable to this change.

Public API:

- [x] I did NOT add new exports to `modules/core/src/index.public.ts`. Not applicable to this change.

Local verification:

- [x] This is a formatting and import organization change with no functional impact.

Skill / docs hygiene:

- [x] No behavior changes requiring documentation updates.
- [x] No new singletons or global state introduced.

## Hotspot files touched

None

## Tests added or updated

None - this is a formatting and import organization refactor with no functional changes.

## Skills reviewed

None

https://claude.ai/code/session_01T4ggJQqz5qEthhAmfYeebd