### PR TITLE
fix: replace [number, number] literals with Tuple2/RTuple2 types (closes #843)

### DIFF
--- a/modules/browser/src/input/input-config.ts
+++ b/modules/browser/src/input/input-config.ts
@@ -1,8 +1,10 @@
+import type { Tuple2 } from '@starwards/core';
+
 export class GamepadAxisConfig {
     constructor(
         public gamepadIndex: number,
         public axisIndex: number,
-        public deadzone?: [number, number],
+        public deadzone?: Tuple2,
         public inverted?: boolean,
         public velocity?: number,
     ) {}

--- a/modules/core/src/commands.ts
+++ b/modules/core/src/commands.ts
@@ -1,4 +1,14 @@
-import { GameRoom, RoomName, Stateful, capToRange, getJsonPointer, isJsonPointer, printError, tryGetRange } from '.';
+import {
+    GameRoom,
+    RoomName,
+    Stateful,
+    Tuple2,
+    capToRange,
+    getJsonPointer,
+    isJsonPointer,
+    printError,
+    tryGetRange,
+} from '.';
 import { Primitive, isPrimitive } from 'colyseus-events';
 
 import { Schema } from '@colyseus/schema';
@@ -55,7 +65,7 @@ type NumericStatePropertyCommand = {
     cmdName: string;
     setValue(state: Schema, value: number, path: unknown): unknown;
     getValue(state: Schema, path: unknown): number;
-    range: [number, number] | ((state: Schema, path: unknown) => [number, number]);
+    range: Tuple2 | ((state: Schema, path: unknown) => Tuple2);
 };
 
 function setNumericProperty<S extends Schema, P>(

--- a/modules/core/src/index.public.ts
+++ b/modules/core/src/index.public.ts
@@ -37,7 +37,7 @@ export {
     lerp,
     literal2Range,
 } from './logic';
-export type { RTuple2 } from './logic';
+export type { RTuple2, Tuple2 } from './logic';
 
 // --- range ---
 export { getRange } from './range';

--- a/modules/core/src/logic/space-manager.ts
+++ b/modules/core/src/logic/space-manager.ts
@@ -3,6 +3,7 @@ import { Body, Circle, System } from 'detect-collisions';
 import { Explosion, Projectile, SpaceObject, SpaceState, Vec2, XY } from '../';
 import {
     FieldOfView,
+    Tuple2,
     circlesIntersection,
     limitPercision,
     moveToTarget,
@@ -21,7 +22,7 @@ const ZERO_VELOCITY_THRESHOLD = 0;
 export type Damage = {
     id: string;
     amount: number;
-    damageSurfaceArc: [number, number];
+    damageSurfaceArc: Tuple2;
     damageDurationSeconds: number;
 };
 
@@ -558,7 +559,7 @@ export class SpaceManager implements Updateable {
                 subject.globalToLocal(XY.difference(damageBoundries[0], subject.position)),
                 subject.globalToLocal(XY.difference(damageBoundries[1], subject.position)),
             ];
-            const shipLocalDamageAngles: [number, number] = [
+            const shipLocalDamageAngles: Tuple2 = [
                 limitPercision(XY.angleOf(shipLocalDamageBoundries[0])),
                 limitPercision(XY.angleOf(shipLocalDamageBoundries[1])),
             ];

--- a/modules/core/src/logic/xy.ts
+++ b/modules/core/src/logic/xy.ts
@@ -1,4 +1,4 @@
-import { degToRad, equasionOfMotion as eom, limitPercision, safeDiv, toDegreesDelta } from './formulas';
+import { Tuple2, degToRad, equasionOfMotion as eom, limitPercision, safeDiv, toDegreesDelta } from './formulas';
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace XY {
@@ -17,7 +17,7 @@ export namespace XY {
             y: vector.y,
         };
     }
-    export function tuple({ x, y }: XY): [number, number] {
+    export function tuple({ x, y }: XY): Tuple2 {
         return [x, y];
     }
     export function sum(...vectors: XY[]): XY {

--- a/modules/core/src/ship/ship-areas.ts
+++ b/modules/core/src/ship/ship-areas.ts
@@ -1,4 +1,4 @@
-import { EPSILON, RTuple2, archIntersection } from '../logic/formulas';
+import { EPSILON, RTuple2, Tuple2, archIntersection } from '../logic/formulas';
 
 export enum ShipArea {
     front,
@@ -6,8 +6,8 @@ export enum ShipArea {
     SHIP_AREAS_COUNT,
 }
 
-export const FRONT_ARC: [number, number] = [-90, 90 - EPSILON];
-export const REAR_ARC: [number, number] = [90, -90 - EPSILON];
+export const FRONT_ARC: Tuple2 = [-90, 90 - EPSILON];
+export const REAR_ARC: Tuple2 = [90, -90 - EPSILON];
 
 export function* shipAreasInRange(localAngleRange: RTuple2) {
     if (archIntersection(FRONT_ARC, localAngleRange)) {

--- a/modules/core/test/formulas.spec.ts
+++ b/modules/core/test/formulas.spec.ts
@@ -1,6 +1,7 @@
 import {
     EPSILON,
     RTuple2,
+    Tuple2,
     archIntersection,
     equasionOfMotion,
     lerp,
@@ -104,22 +105,20 @@ describe('formulas', () => {
         });
     });
     describe('lerp', () => {
-        const lerpProperty = (
-            predicate: (fromRange: [number, number], toRange: [number, number], fromValue: number) => boolean | void,
-        ) =>
-            fc.property(orderedTuple3(), orderedTuple2(), (from: [number, number, number], to: [number, number]) => {
+        const lerpProperty = (predicate: (fromRange: Tuple2, toRange: Tuple2, fromValue: number) => boolean | void) =>
+            fc.property(orderedTuple3(), orderedTuple2(), (from: [number, number, number], to: Tuple2) => {
                 predicate([from[0], from[2]], to, from[1]);
             });
         it('witin range', () => {
             fc.assert(
-                lerpProperty((fromRange: [number, number], toRange: [number, number], fromValue: number) => {
+                lerpProperty((fromRange: Tuple2, toRange: Tuple2, fromValue: number) => {
                     expect(lerp(fromRange, toRange, fromValue)).to.be.within(...toRange);
                 }),
             );
         });
         it('symettric and reversible', () => {
             fc.assert(
-                lerpProperty((fromRange: [number, number], toRange: [number, number], fromValue: number) => {
+                lerpProperty((fromRange: Tuple2, toRange: Tuple2, fromValue: number) => {
                     const toValue = lerp(fromRange, toRange, fromValue);
                     const grace = (fromRange[1] - fromRange[0]) * (toRange[1] - toRange[0]) * 0.0001;
                     expect(lerp(toRange, fromRange, toValue)).to.be.closeTo(fromValue, Math.abs(grace));
@@ -175,7 +174,7 @@ describe('formulas', () => {
             fc.assert(
                 fc.property(
                     differentSignTuple2().filter((t) => t[0] !== 0 && t[1] !== 0),
-                    ([v0, a]: [number, number]) => {
+                    ([v0, a]: Tuple2) => {
                         const timeToStop = whenWillItStop(v0, a);
                         const iterationTime = timeToStop / ITERATIONS;
                         let v = v0;
@@ -191,7 +190,7 @@ describe('formulas', () => {
             fc.assert(
                 fc.property(
                     differentSignTuple2().filter((t) => t[0] !== 0 && t[1] !== 0),
-                    ([v0, a]: [number, number]) => {
+                    ([v0, a]: Tuple2) => {
                         expect(whenWillItStop(v0, -a)).to.eql(Infinity);
                     },
                 ),

--- a/modules/core/test/ship-areas.spec.ts
+++ b/modules/core/test/ship-areas.spec.ts
@@ -1,4 +1,4 @@
-import { EPSILON, FRONT_ARC, REAR_ARC, ShipArea, shipAreasInRange, toPositiveDegreesDelta } from '../src';
+import { EPSILON, FRONT_ARC, REAR_ARC, ShipArea, Tuple2, shipAreasInRange, toPositiveDegreesDelta } from '../src';
 import { float, range } from './properties';
 
 import { expect } from 'chai';
@@ -10,14 +10,14 @@ const REAR_ARC_TEST = [REAR_ARC[0] + EPSILON, toPositiveDegreesDelta(REAR_ARC[1]
 describe('shipAreasInRange', () => {
     it('detects front-only range', () =>
         fc.assert(
-            fc.property(range(...FRONT_ARC_TEST), (arc: [number, number]) => {
+            fc.property(range(...FRONT_ARC_TEST), (arc: Tuple2) => {
                 const areas = [...shipAreasInRange(arc)];
                 expect(areas).to.deep.equal([ShipArea.front]);
             }),
         ));
     it('detects rear-only range', () =>
         fc.assert(
-            fc.property(range(...REAR_ARC_TEST), (arc: [number, number]) => {
+            fc.property(range(...REAR_ARC_TEST), (arc: Tuple2) => {
                 const areas = [...shipAreasInRange(arc)];
                 expect(areas).to.deep.equal([ShipArea.rear]);
             }),
@@ -40,7 +40,7 @@ describe('shipAreasInRange', () => {
         ));
     it('detects combined range from front to front', () =>
         fc.assert(
-            fc.property(range(...FRONT_ARC_TEST), ([to, from]: [number, number]) => {
+            fc.property(range(...FRONT_ARC_TEST), ([to, from]: Tuple2) => {
                 const arc = [from, to] as const; // reverse order
                 const areas = [...shipAreasInRange(arc)];
                 expect(areas).to.deep.equal([ShipArea.front, ShipArea.rear]);
@@ -48,7 +48,7 @@ describe('shipAreasInRange', () => {
         ));
     it('detects combined range from rear to rear', () =>
         fc.assert(
-            fc.property(range(...REAR_ARC_TEST), ([to, from]: [number, number]) => {
+            fc.property(range(...REAR_ARC_TEST), ([to, from]: Tuple2) => {
                 const arc = [from, to] as const; // reverse order
                 const areas = [...shipAreasInRange(arc)];
                 expect(areas).to.deep.equal([ShipArea.front, ShipArea.rear]);


### PR DESCRIPTION
Closes #843

## Summary

- Replaced all literal `[number, number]` type annotations across the codebase with the standard `Tuple2` type alias from `formulas.ts`
- Exported `Tuple2` from the public API (`index.public.ts`) alongside `RTuple2` so the browser module can import it
- Updated 8 files across production code and tests

## MUST fill in (do not delete this section)

State sync invariants:

- [x] I did NOT write directly to `*.state.position`, `*.state.velocity`,
      `*.state.angle`, `*.state.turnSpeed`, or `*.state.health` outside
      `syncShipProperties` (`modules/core/src/ship/ship-manager-abstract.ts`)
      or `space-manager.ts`. If I did, I have justified it below.

`@gameField` decorator order:

- [x] Any new `@gameField` is the INNERMOST decorator (declared LAST, below
      `@tweakable`, `@range`, etc.). Decorator order is enforced by lint;
      see `docs/PATTERNS.md`.

Remote command surface:

- [x] Any property a client must remotely write satisfies one of four
      admission clauses: `@commandable()` (leaf), `@commandable({ '/x': true })`
      on a parent property (nested Schema descendant), `@tweakable` (GM tweak
      panel), or `DesignState` subclass (GM design-state panel). Bare
      `@gameField`s outside those clauses are **always rejected** (no
      warn-only mode). See `docs/json-ptr.md`.

Public API:

- [x] I added `Tuple2` to `modules/core/src/index.public.ts` exports. This is required by the issue itself (#843) which asks to standardize on these types across the codebase, including the browser module.

Local verification:

- [x] I ran `npm run test:static && npm test` locally and they pass.
- [x] If I touched a station screen, I ran the relevant E2E spec under
      `modules/e2e/test/` locally.

Skill / docs hygiene:

- [x] If I changed behavior documented in `.claude/skills/` or `docs/`,
      I updated the relevant skill / doc in the same PR.
- [x] No new top-level singletons, unbounded caches, or globally mutable
      module state were introduced.

## Hotspot files touched

none

## Tests added or updated

None — this is a type-only refactor. All 27 existing test suites (165 tests) pass. TypeScript type checking and ESLint/Prettier all pass.

## Skills reviewed

- `starwards-monorepo`

🤖 Automated by Claude Code