### PR TITLE
fix: reset radar damage in resetShipState (closes #866)

### DIFF
--- a/modules/core/src/ship/ship-manager-abstract.ts
+++ b/modules/core/src/ship/ship-manager-abstract.ts
@@ -47,6 +47,7 @@ export function resetShipState(state: ShipState) {
     for (const thruster of state.thrusters) {
         resetThruster(thruster);
     }
+    state.radar.malfunctionRangeFactor = 0;
     state.smartPilot.offsetFactor = 0;
     state.magazine.count_CannonShell = state.magazine.max_CannonShell;
     // Reset non-@gameField command properties that Schema.clone() does not copy.

--- a/modules/core/test/ship-manager-abstract.spec.ts
+++ b/modules/core/test/ship-manager-abstract.spec.ts
@@ -122,6 +122,16 @@ describe.each([ShipManagerPc, ShipManagerNpc])('%p', (shipManagerCtor) => {
         expect(state.maneuvering.afterBurnerFuel).to.equal(state.maneuvering.design.maxAfterBurnerFuel);
     });
 
+    it('resetShipState resets radar malfunctionRangeFactor', () => {
+        const state = makeShipState('test', dragonflyConfig);
+
+        state.radar.malfunctionRangeFactor = 0.5;
+
+        resetShipState(state);
+
+        expect(state.radar.malfunctionRangeFactor).to.equal(0);
+    });
+
     it('resetShipState restores magazine count', () => {
         const state = makeShipState('test', dragonflyConfig);
 


### PR DESCRIPTION
Closes #866

## Summary

- Reset `radar.malfunctionRangeFactor` to `0` (its normal/undamaged value) in `resetShipState()`
- Without this fix, radar damage persisted across GM ship resets during multi-hour LARP events
- Added test verifying the radar reset behavior

## MUST fill in (do not delete this section)

State sync invariants:

- [x] I did NOT write directly to `*.state.position`, `*.state.velocity`,
      `*.state.angle`, `*.state.turnSpeed`, or `*.state.health` outside
      `syncShipProperties` (`modules/core/src/ship/ship-manager-abstract.ts`)
      or `space-manager.ts`. If I did, I have justified it below.

`@gameField` decorator order:

- [x] Any new `@gameField` is the INNERMOST decorator (declared LAST, below
      `@tweakable`, `@range`, etc.). Decorator order is enforced by lint;
      see `docs/PATTERNS.md`.

Remote command surface:

- [x] Any property a client must remotely write satisfies one of four
      admission clauses: `@commandable()` (leaf), `@commandable({ '/x': true })`
      on a parent property (nested Schema descendant), `@tweakable` (GM tweak
      panel), or `DesignState` subclass (GM design-state panel). Bare
      `@gameField`s outside those clauses are **always rejected** (no
      warn-only mode). See `docs/json-ptr.md`.

Public API:

- [x] I did NOT add new exports to `modules/core/src/index.public.ts`
      without explicit reviewer approval. Internal symbols belong in
      `index.internal.ts` and are imported via `@starwards/core/internal`.

Local verification:

- [x] I ran `npm run test:static && npm test` locally and they pass.
- [x] If I touched a station screen, I ran the relevant E2E spec under
      `modules/e2e/test/` locally.

Skill / docs hygiene:

- [x] If I changed behavior documented in `.claude/skills/` or `docs/`,
      I updated the relevant skill / doc in the same PR.
- [x] No new top-level singletons, unbounded caches, or globally mutable
      module state were introduced.

## Hotspot files touched

- `modules/core/src/ship/ship-manager-abstract.ts` — added `state.radar.malfunctionRangeFactor = 0` to `resetShipState()`

## Tests added or updated

- `modules/core/test/ship-manager-abstract.spec.ts` — new test: `resetShipState resets radar malfunctionRangeFactor`

🤖 Automated by Claude Code