### PR TITLE
fix: preserve formation when GM orders multiple ships to move (closes #853)

### DIFF
--- a/modules/core/src/logic/space-manager.ts
+++ b/modules/core/src/logic/space-manager.ts
@@ -205,10 +205,10 @@ export class SpaceManager implements Updateable {
                 for (const id of cmd.ids) {
                     const [subject] = this.getObjectPtr(id);
                     if (subject && Spaceship.isInstance(subject)) {
-                        ships.push({ id, position: subject.position });
+                        ships.push({ id, position: XY.clone(subject.position) });
                     }
                 }
-                if (ships.length > 0) {
+                if (ships.length > 1) {
                     const center = XY.scale(XY.sum(...ships.map((s) => s.position)), 1 / ships.length);
                     for (const ship of ships) {
                         const offset = XY.difference(ship.position, center);
@@ -217,6 +217,8 @@ export class SpaceManager implements Updateable {
                             position: XY.add(cmd.order.position, offset),
                         });
                     }
+                } else if (ships.length === 1) {
+                    this.objectOrder.set(ships[0].id, cmd.order);
                 }
             } else {
                 for (const id of cmd.ids) {

--- a/modules/core/src/logic/space-manager.ts
+++ b/modules/core/src/logic/space-manager.ts
@@ -199,10 +199,31 @@ export class SpaceManager implements Updateable {
         this.state.moveCommands = [];
 
         for (const cmd of this.state.botOrderCommands) {
-            for (const id of cmd.ids) {
-                const [subject] = this.getObjectPtr(id);
-                if (subject && Spaceship.isInstance(subject)) {
-                    this.objectOrder.set(id, cmd.order);
+            if (cmd.order.type === 'move' && cmd.ids.length > 1) {
+                // For multi-ship move orders, preserve relative formation
+                const ships: Array<{ id: string; position: XY }> = [];
+                for (const id of cmd.ids) {
+                    const [subject] = this.getObjectPtr(id);
+                    if (subject && Spaceship.isInstance(subject)) {
+                        ships.push({ id, position: subject.position });
+                    }
+                }
+                if (ships.length > 0) {
+                    const center = XY.scale(XY.sum(...ships.map((s) => s.position)), 1 / ships.length);
+                    for (const ship of ships) {
+                        const offset = XY.difference(ship.position, center);
+                        this.objectOrder.set(ship.id, {
+                            type: 'move',
+                            position: XY.add(cmd.order.position, offset),
+                        });
+                    }
+                }
+            } else {
+                for (const id of cmd.ids) {
+                    const [subject] = this.getObjectPtr(id);
+                    if (subject && Spaceship.isInstance(subject)) {
+                        this.objectOrder.set(id, cmd.order);
+                    }
                 }
             }
         }

--- a/modules/core/test/space-manager.spec.ts
+++ b/modules/core/test/space-manager.spec.ts
@@ -287,6 +287,118 @@ describe('SpaceManager', () => {
         });
     });
 
+    describe('multi-ship move order preserves formation', () => {
+        it('assigns per-ship destination offsets from group center', () => {
+            const spaceMgr = new SpaceManager();
+            const shipA = new Spaceship();
+            shipA.id = 'ship-a';
+            shipA.position = Vec2.make({ x: 100, y: 100 });
+            const shipB = new Spaceship();
+            shipB.id = 'ship-b';
+            shipB.position = Vec2.make({ x: 200, y: 100 });
+            const shipC = new Spaceship();
+            shipC.id = 'ship-c';
+            shipC.position = Vec2.make({ x: 100, y: 200 });
+
+            spaceMgr.insertBulk([shipA, shipB, shipC]);
+            spaceMgr.forceFlushEntities();
+
+            // Issue a bulk move order to all 3 ships
+            const targetPosition = { x: 500, y: 500 };
+            spaceMgr.state.botOrderCommands.push({
+                ids: ['ship-a', 'ship-b', 'ship-c'],
+                order: { type: 'move', position: targetPosition },
+            });
+
+            // Run one update tick to process the command
+            spaceMgr.update({ deltaSeconds: 0.1, deltaSecondsAvg: 0.1, totalSeconds: 0.1 });
+
+            // Group center is (133.33, 133.33)
+            // Ship A offset: (-33.33, -33.33) → destination ≈ (466.67, 466.67)
+            // Ship B offset: (66.67, -33.33) → destination ≈ (566.67, 466.67)
+            // Ship C offset: (-33.33, 66.67) → destination ≈ (466.67, 566.67)
+            const orderA = spaceMgr.resolveObjectOrder('ship-a');
+            const orderB = spaceMgr.resolveObjectOrder('ship-b');
+            const orderC = spaceMgr.resolveObjectOrder('ship-c');
+
+            expect(orderA).to.not.equal(null);
+            expect(orderB).to.not.equal(null);
+            expect(orderC).to.not.equal(null);
+            expect(orderA!.type).to.equal('move');
+            expect(orderB!.type).to.equal('move');
+            expect(orderC!.type).to.equal('move');
+
+            if (orderA!.type === 'move' && orderB!.type === 'move' && orderC!.type === 'move') {
+                // Each ship should have a different destination
+                expect(orderA!.position.x).to.not.equal(orderB!.position.x);
+                expect(orderA!.position.y).to.not.equal(orderC!.position.y);
+
+                // Relative offsets should be preserved
+                const abDiffX = orderB!.position.x - orderA!.position.x;
+                const acDiffY = orderC!.position.y - orderA!.position.y;
+                expect(abDiffX).to.be.closeTo(100, 1); // Ship B was 100 units right of Ship A
+                expect(acDiffY).to.be.closeTo(100, 1); // Ship C was 100 units below Ship A
+            }
+        });
+
+        it('single-ship move order uses exact target position', () => {
+            const spaceMgr = new SpaceManager();
+            const ship = new Spaceship();
+            ship.id = 'solo-ship';
+            ship.position = Vec2.make({ x: 100, y: 100 });
+
+            spaceMgr.insert(ship);
+            spaceMgr.forceFlushEntities();
+
+            const targetPosition = { x: 500, y: 500 };
+            spaceMgr.state.botOrderCommands.push({
+                ids: ['solo-ship'],
+                order: { type: 'move', position: targetPosition },
+            });
+
+            spaceMgr.update({ deltaSeconds: 0.1, deltaSecondsAvg: 0.1, totalSeconds: 0.1 });
+
+            const order = spaceMgr.resolveObjectOrder('solo-ship');
+            expect(order).to.not.equal(null);
+            expect(order!.type).to.equal('move');
+            if (order!.type === 'move') {
+                expect(order!.position.x).to.equal(500);
+                expect(order!.position.y).to.equal(500);
+            }
+        });
+
+        it('non-move orders are unaffected by formation logic', () => {
+            const spaceMgr = new SpaceManager();
+            const shipA = new Spaceship();
+            shipA.id = 'atk-a';
+            shipA.position = Vec2.make({ x: 100, y: 100 });
+            const shipB = new Spaceship();
+            shipB.id = 'atk-b';
+            shipB.position = Vec2.make({ x: 200, y: 200 });
+
+            spaceMgr.insertBulk([shipA, shipB]);
+            spaceMgr.forceFlushEntities();
+
+            spaceMgr.state.botOrderCommands.push({
+                ids: ['atk-a', 'atk-b'],
+                order: { type: 'attack', targetId: 'enemy-1' },
+            });
+
+            spaceMgr.update({ deltaSeconds: 0.1, deltaSecondsAvg: 0.1, totalSeconds: 0.1 });
+
+            const orderA = spaceMgr.resolveObjectOrder('atk-a');
+            const orderB = spaceMgr.resolveObjectOrder('atk-b');
+            expect(orderA).to.not.equal(null);
+            expect(orderB).to.not.equal(null);
+            expect(orderA!.type).to.equal('attack');
+            expect(orderB!.type).to.equal('attack');
+            if (orderA!.type === 'attack' && orderB!.type === 'attack') {
+                expect(orderA!.targetId).to.equal('enemy-1');
+                expect(orderB!.targetId).to.equal('enemy-1');
+            }
+        });
+    });
+
     it('insert adds object to state', () => {
         const spaceMgr = new SpaceManager();
         const ship = new Spaceship();

--- a/modules/core/test/space-manager.spec.ts
+++ b/modules/core/test/space-manager.spec.ts
@@ -397,6 +397,66 @@ describe('SpaceManager', () => {
                 expect(orderB!.targetId).to.equal('enemy-1');
             }
         });
+
+        it('multi-ship command with some invalid IDs still dispatches to valid ships', () => {
+            const spaceMgr = new SpaceManager();
+            const shipA = new Spaceship();
+            shipA.id = 'valid-a';
+            shipA.position = Vec2.make({ x: 100, y: 100 });
+            const shipB = new Spaceship();
+            shipB.id = 'valid-b';
+            shipB.position = Vec2.make({ x: 200, y: 100 });
+
+            spaceMgr.insertBulk([shipA, shipB]);
+            spaceMgr.forceFlushEntities();
+
+            // Include a non-existent ship ID alongside valid ones
+            spaceMgr.state.botOrderCommands.push({
+                ids: ['valid-a', 'destroyed-ship', 'valid-b'],
+                order: { type: 'move', position: { x: 500, y: 500 } },
+            });
+
+            spaceMgr.update({ deltaSeconds: 0.1, deltaSecondsAvg: 0.1, totalSeconds: 0.1 });
+
+            const orderA = spaceMgr.resolveObjectOrder('valid-a');
+            const orderB = spaceMgr.resolveObjectOrder('valid-b');
+            const orderGhost = spaceMgr.resolveObjectOrder('destroyed-ship');
+
+            expect(orderA).to.not.equal(null);
+            expect(orderB).to.not.equal(null);
+            expect(orderGhost).to.equal(null);
+
+            if (orderA!.type === 'move' && orderB!.type === 'move') {
+                // Relative offset between A and B should be preserved (100 units apart on x)
+                expect(orderB!.position.x - orderA!.position.x).to.be.closeTo(100, 1);
+                expect(orderB!.position.y - orderA!.position.y).to.be.closeTo(0, 1);
+            }
+        });
+
+        it('multi-ship command with only one valid ship uses exact target position', () => {
+            const spaceMgr = new SpaceManager();
+            const ship = new Spaceship();
+            ship.id = 'sole-survivor';
+            ship.position = Vec2.make({ x: 100, y: 100 });
+
+            spaceMgr.insert(ship);
+            spaceMgr.forceFlushEntities();
+
+            spaceMgr.state.botOrderCommands.push({
+                ids: ['sole-survivor', 'ghost-1', 'ghost-2'],
+                order: { type: 'move', position: { x: 500, y: 500 } },
+            });
+
+            spaceMgr.update({ deltaSeconds: 0.1, deltaSecondsAvg: 0.1, totalSeconds: 0.1 });
+
+            const order = spaceMgr.resolveObjectOrder('sole-survivor');
+            expect(order).to.not.equal(null);
+            expect(order!.type).to.equal('move');
+            if (order!.type === 'move') {
+                expect(order!.position.x).to.equal(500);
+                expect(order!.position.y).to.equal(500);
+            }
+        });
     });
 
     it('insert adds object to state', () => {


### PR DESCRIPTION
Closes #853

## Summary

- When the GM selects multiple ships and right-clicks to order them to a destination, each ship now receives a unique destination that preserves its relative position within the group formation
- Previously all ships converged on the exact same point; now each ship's destination is offset by its distance from the group center
- The fix is in `SpaceManager.update()` where bulk bot orders are dispatched — for multi-ship move orders, it calculates the group centroid and applies per-ship offsets to the target position
- Single-ship moves and non-move orders (attack, follow) are unaffected

## MUST fill in (do not delete this section)

State sync invariants:

- [x] I did NOT write directly to `*.state.position`, `*.state.velocity`,
      `*.state.angle`, `*.state.turnSpeed`, or `*.state.health` outside
      `syncShipProperties` (`modules/core/src/ship/ship-manager-abstract.ts`)
      or `space-manager.ts`. If I did, I have justified it below.

`@gameField` decorator order:

- [x] Any new `@gameField` is the INNERMOST decorator (declared LAST, below
      `@tweakable`, `@range`, etc.). Decorator order is enforced by lint;
      see `docs/PATTERNS.md`.

Remote command surface:

- [x] Any property a client must remotely write satisfies one of four
      admission clauses: `@commandable()` (leaf), `@commandable({ '/x': true })`
      on a parent property (nested Schema descendant), `@tweakable` (GM tweak
      panel), or `DesignState` subclass (GM design-state panel). Bare
      `@gameField`s outside those clauses are **always rejected** (no
      warn-only mode). See `docs/json-ptr.md`.

Public API:

- [x] I did NOT add new exports to `modules/core/src/index.public.ts`
      without explicit reviewer approval. Internal symbols belong in
      `index.internal.ts` and are imported via `@starwards/core/internal`.

Local verification:

- [x] I ran `npm run test:static && npm test` locally and they pass.
- [x] If I touched a station screen, I ran the relevant E2E spec under
      `modules/e2e/test/` locally.

Skill / docs hygiene:

- [x] If I changed behavior documented in `.claude/skills/` or `docs/`,
      I updated the relevant skill / doc in the same PR.
- [x] No new top-level singletons, unbounded caches, or globally mutable
      module state were introduced.

## Hotspot files touched

- `modules/core/src/logic/space-manager.ts` — modified bot order dispatch logic in `update()`

## Tests added or updated

- `modules/core/test/space-manager.spec.ts` — 3 new tests:
  - `assigns per-ship destination offsets from group center` — verifies multi-ship formation preservation
  - `single-ship move order uses exact target position` — verifies no regression for single-ship moves
  - `non-move orders are unaffected by formation logic` — verifies attack/follow orders pass through unchanged

🤖 Automated by Claude Code