### PR TITLE
feat: name ship systems models and display in tweak panel (closes #967)

### DIFF
--- a/modules/browser/src/widgets/design-state.ts
+++ b/modules/browser/src/widgets/design-state.ts
@@ -9,12 +9,16 @@ import { WidgetContainer } from '../container';
 
 function addDesignStateToPanel(panel: Panel, shipDriver: ShipDriver, pointerStr: string) {
     const p = readProp<DesignState>(shipDriver, pointerStr);
-    const fields = new Set(p.getValue()?.keys());
+    // modelName is a string field (see DesignState in core), whereas
+    // `addConfig` here wires up numeric sliders. Exclude it from this
+    // legacy panel — the tweak widget shows it in the system header.
+    const fields = new Set([...(p.getValue()?.keys() ?? [])].filter((k) => k !== 'modelName'));
     for (const constName of fields) {
         panel.addConfig(constName, readWriteProp(shipDriver, pointerStr + '/' + constName));
     }
     p.onChange(() => {
         for (const constName of p.getValue()?.keys() || []) {
+            if (constName === 'modelName') continue;
             if (!fields.has(constName)) {
                 fields.add(constName);
                 panel.addConfig(constName, readWriteProp(shipDriver, pointerStr + '/' + constName));

--- a/modules/browser/src/widgets/tweak.ts
+++ b/modules/browser/src/widgets/tweak.ts
@@ -159,8 +159,9 @@ const singleSelectionDetails = async (
         );
         addDesignFolder(shipDriver, armorFolder, `/armor`, cleanup);
         for (const system of shipDriver.systems) {
+            const modelName = system.state.design?.modelName;
             const systemFolder = guiFolder.addFolder({
-                title: system.state.name,
+                title: modelName ? `${system.state.name} — ${modelName}` : system.state.name,
                 expanded: false,
             });
             cleanup(() => systemFolder.dispose());
@@ -247,7 +248,15 @@ function addDesignFolder(
     cleanup(() => designFolder.dispose());
     const state = readProp<DesignState>(shipDriver, `${pointer}/design`).getValue();
     if (!state) return;
+    // Show the string modelName (if set) as a read-only text field at the top
+    // of the design folder.
+    if (state.modelName) {
+        const modelNameProp = readProp<string>(shipDriver, `${pointer}/design/modelName`);
+        addTextBlade(designFolder, modelNameProp, { label: 'modelName', disabled: true }, cleanup);
+    }
     for (const designParam of state.keys()) {
+        // modelName is a string, shown above instead of as a numeric slider.
+        if (designParam === 'modelName') continue;
         const prop = readWriteProp<number>(shipDriver, `${pointer}/design/${designParam}`);
         addCameraRingBlade(designFolder, prop, { label: designParam }, cleanup);
     }

--- a/modules/core/src/configurations/dragonfly-sf-22.ts
+++ b/modules/core/src/configurations/dragonfly-sf-22.ts
@@ -1,11 +1,13 @@
 import { ShipDesign } from '../ship';
 
 export const dragonflyArmor = {
+    modelName: 'Aegis-12 Plated Armor',
     numberOfPlates: 12,
     healRate: 3,
     plateMaxHealth: 1500,
 };
 export const dragonflyThruster = {
+    modelName: 'RT-150 Vectored Thruster',
     maxAngleError: 45,
     capacity: 150,
     energyCost: 0.07,
@@ -13,6 +15,7 @@ export const dragonflyThruster = {
     damage50: 15,
 };
 export const dragonflyRadar = {
+    modelName: 'Argus-10k Phased Radar',
     damage50: 20,
     range: 10_000,
     energyCost: 0.05,
@@ -20,6 +23,7 @@ export const dragonflyRadar = {
     malfunctionRange: 5_000,
 };
 export const dragonflyChaingun = {
+    modelName: 'Hailstorm 20RPS Chaingun',
     bulletsPerSecond: 20,
     bulletSpeed: 1000,
     bulletDegreesDeviation: 1,
@@ -32,6 +36,7 @@ export const dragonflyChaingun = {
     energyCost: 1,
 };
 export const dragonflyReactor = {
+    modelName: 'Helios-1000 Fusion Reactor',
     energyPerSecond: 5,
     maxEnergy: 1000,
     energyHeatEPMThreshold: 20,
@@ -39,10 +44,12 @@ export const dragonflyReactor = {
     damage50: 20,
 };
 export const dragonflyProperties = {
+    modelName: 'Dragonfly SF-22 Frame',
     totalCoolant: 10,
     systemKillRatio: 0.5,
 };
 export const dragonflyMagazine = {
+    modelName: 'Hornet Mk-II Magazine',
     max_CannonShell: 3600,
     max_BlastCannonShell: 2000,
     max_Missile: 20,
@@ -51,6 +58,7 @@ export const dragonflyMagazine = {
     capacityDamageFactor: 0.1,
 };
 export const dragonflySmartPilot = {
+    modelName: 'Nimbus-3 Smart Pilot',
     maxTargetAimOffset: 30,
     aimOffsetSpeed: 15,
     maxTurnSpeed: 90,
@@ -60,6 +68,7 @@ export const dragonflySmartPilot = {
     maxSpeedFromAfterBurner: 300,
 };
 export const dragonflyTube = {
+    modelName: 'Stinger Missile Tube',
     damage50: 20,
     bulletsPerSecond: 1,
     bulletSpeed: 1000,
@@ -72,10 +81,12 @@ export const dragonflyTube = {
     use_Missile: true,
 };
 export const dragonflyTargeting = {
+    modelName: 'Falcon Targeting Computer',
     maxRange: 5_000,
     shortRange: 3_000,
 };
 export const dragonflyWarp = {
+    modelName: 'Voyager-X Warp Drive',
     damage50: 20,
     maxProximity: 10_000,
     chargeTime: 10,
@@ -87,6 +98,7 @@ export const dragonflyWarp = {
     secondsToChangeFrequency: 10,
 };
 export const dragonflyDocking = {
+    modelName: 'Gripper-1 Docking Clamp',
     damage50: 20,
     maxDockingDistance: 1_000,
     maxDockedDistance: 20,
@@ -95,6 +107,7 @@ export const dragonflyDocking = {
     width: 45,
 };
 export const dragonflyManeuvering = {
+    modelName: 'Pivot-25 Maneuvering Suite',
     rotationCapacity: 25,
     rotationEnergyCost: 0.07,
     maxAfterBurnerFuel: 5000,

--- a/modules/core/src/ship/armor.ts
+++ b/modules/core/src/ship/armor.ts
@@ -7,6 +7,7 @@ import { gameField } from '../game-field';
 import { range } from '../range';
 
 export type ArmorDesign = {
+    modelName?: string;
     numberOfPlates: number;
     healRate: number;
     plateMaxHealth: number;

--- a/modules/core/src/ship/chain-gun.ts
+++ b/modules/core/src/ship/chain-gun.ts
@@ -11,6 +11,7 @@ export type SelectedProjectileModel = 'None' | ProjectileModel;
 
 // Properties with underline ( _ ) are templated after Projectile types, and are accessed in a generic way.
 export type ChaingunDesign = {
+    modelName?: string;
     bulletsPerSecond: number;
     bulletSpeed: number;
     bulletDegreesDeviation: number;

--- a/modules/core/src/ship/docking.ts
+++ b/modules/core/src/ship/docking.ts
@@ -13,6 +13,7 @@ export enum DockingMode {
 }
 
 export type DockingDesign = {
+    modelName?: string;
     damage50: number;
     maxDockingDistance: number;
     maxDockedDistance: number;

--- a/modules/core/src/ship/magazine.ts
+++ b/modules/core/src/ship/magazine.ts
@@ -7,6 +7,7 @@ import { tweakable } from '../tweakable';
 // Properties with underline ( _ ) are templated after Projectile types, and are accessed in a generic way.
 
 export type MagazineDesign = {
+    modelName?: string;
     damage50: number;
     max_CannonShell: number;
     max_BlastCannonShell: number;

--- a/modules/core/src/ship/maneuvering.ts
+++ b/modules/core/src/ship/maneuvering.ts
@@ -5,6 +5,7 @@ import { range } from '../range';
 import { tweakable } from '../tweakable';
 
 export type ManeuveringDesign = {
+    modelName?: string;
     rotationCapacity: number;
     rotationEnergyCost: number;
     maxAfterBurnerFuel: number;

--- a/modules/core/src/ship/radar.ts
+++ b/modules/core/src/ship/radar.ts
@@ -5,6 +5,7 @@ import { gameField } from '../game-field';
 import { range } from '../range';
 
 export type RadarDesign = {
+    modelName?: string;
     damage50: number;
     range: number;
     /**

--- a/modules/core/src/ship/reactor.ts
+++ b/modules/core/src/ship/reactor.ts
@@ -5,6 +5,7 @@ import { range } from '../range';
 import { tweakable } from '../tweakable';
 
 export type ReactorDesign = {
+    modelName?: string;
     energyPerSecond: number;
     maxEnergy: number;
     energyHeatEPMThreshold: number;

--- a/modules/core/src/ship/ship-state.ts
+++ b/modules/core/src/ship/ship-state.ts
@@ -40,6 +40,7 @@ export enum Order {
 }
 
 export type ShipPropertiesDesign = {
+    modelName?: string;
     totalCoolant: number;
     systemKillRatio: number; // ratio of broken systems to cause ship death. <=0 means death on first hit, >1 means can't be killed
 };

--- a/modules/core/src/ship/smart-pilot.ts
+++ b/modules/core/src/ship/smart-pilot.ts
@@ -6,6 +6,7 @@ import { range } from '../range';
 import { tweakable } from '../tweakable';
 
 export type SmartPilotDesign = {
+    modelName?: string;
     maxTargetAimOffset: number;
     aimOffsetSpeed: number;
     maxTurnSpeed: number;

--- a/modules/core/src/ship/system.ts
+++ b/modules/core/src/ship/system.ts
@@ -28,6 +28,14 @@ export abstract class DesignState extends Schema {
      */
     static readonly isStarwardsDesignState = true;
 
+    /**
+     * Model name for this system instance, configured per ship design
+     * (see `modules/core/src/configurations/`). Displayed in the GM
+     * tweak panel so players / GM can tell which specific make/model of a
+     * system is installed on a ship. Empty string means "not named".
+     */
+    @gameField('string') modelName = '';
+
     keys() {
         // In Colyseus schema v3, use Symbol.metadata to access schema property definitions
         /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unnecessary-type-assertion */

--- a/modules/core/src/ship/targeting.ts
+++ b/modules/core/src/ship/targeting.ts
@@ -5,6 +5,7 @@ import { Schema } from '@colyseus/schema';
 import { tweakable } from '../tweakable';
 
 export type TargetingDesign = {
+    modelName?: string;
     maxRange: number;
     shortRange: number;
 };

--- a/modules/core/src/ship/thruster.ts
+++ b/modules/core/src/ship/thruster.ts
@@ -8,6 +8,7 @@ import { gameField } from '../game-field';
 import { range } from '../range';
 
 export type ThrusterDesign = {
+    modelName?: string;
     maxAngleError: number;
     capacity: number;
     energyCost: number;

--- a/modules/core/src/ship/warp.ts
+++ b/modules/core/src/ship/warp.ts
@@ -5,6 +5,7 @@ import { range } from '../range';
 import { tweakable } from '../tweakable';
 
 export type WarpDesign = {
+    modelName?: string;
     damage50: number;
     maxProximity: number;
     chargeTime: number;

--- a/modules/core/test/ship-manager-abstract.spec.ts
+++ b/modules/core/test/ship-manager-abstract.spec.ts
@@ -131,4 +131,28 @@ describe.each([ShipManagerPc, ShipManagerNpc])('%p', (shipManagerCtor) => {
 
         expect(state.magazine.count_CannonShell).to.equal(state.magazine.max_CannonShell);
     });
+
+    it('ship systems carry the modelName configured in the ship design', () => {
+        const state = makeShipState('test', dragonflyConfig);
+
+        expect(state.design.modelName).to.equal(dragonflyConfig.properties.modelName);
+        expect(state.armor.design.modelName).to.equal(dragonflyConfig.armor.modelName);
+        expect(state.radar.design.modelName).to.equal(dragonflyConfig.radar.modelName);
+        expect(state.reactor.design.modelName).to.equal(dragonflyConfig.reactor.modelName);
+        expect(state.smartPilot.design.modelName).to.equal(dragonflyConfig.smartPilot.modelName);
+        expect(state.magazine.design.modelName).to.equal(dragonflyConfig.magazine.modelName);
+        expect(state.weaponsTarget.design.modelName).to.equal(dragonflyConfig.weaponsTarget.modelName);
+        expect(state.warp.design.modelName).to.equal(dragonflyConfig.warp.modelName);
+        expect(state.docking.design.modelName).to.equal(dragonflyConfig.docking.modelName);
+        expect(state.maneuvering.design.modelName).to.equal(dragonflyConfig.maneuvering.modelName);
+        if (state.chainGun) {
+            expect(state.chainGun.design.modelName).to.equal(dragonflyConfig.chainGun?.modelName);
+        }
+        for (const thruster of state.thrusters) {
+            expect(thruster.design.modelName).to.equal(dragonflyConfig.thrusters[thruster.index][1].modelName);
+        }
+        for (const tube of state.tubes) {
+            expect(tube.design.modelName).to.equal(dragonflyConfig.tubes[tube.index][1].modelName);
+        }
+    });
 });


### PR DESCRIPTION
Closes #967

## Summary

- Added a `modelName` field on the abstract `DesignState` base class (`modules/core/src/ship/system.ts`) so every subsystem carries a per-instance model name that syncs to clients via Colyseus.
- Added optional `modelName?: string` to every `*Design` type (armor, thruster, radar, reactor, chain gun, magazine, smart pilot, targeting, warp, docking, maneuvering, ship properties) so ship configurations can name each system.
- Named each system in the Dragonfly SF-22 configuration (e.g. `Argus-10k Phased Radar`, `Helios-1000 Fusion Reactor`, `Hailstorm 20RPS Chaingun`, …).
- Displayed the `modelName` in the GM tweak panel:
  - The system folder title now reads `<system type> — <model name>` when set.
  - The system's design sub-folder shows the model name as a read-only text blade at the top.
  - Skipped `modelName` in the numeric slider iteration in both the tweak widget (`tweak.ts::addDesignFolder`) and the legacy `design-state.ts` widget.
- Added a test in `ship-manager-abstract.spec.ts` verifying every system instance carries the configured `modelName` from the Dragonfly SF-22 design.

## MUST fill in (do not delete this section)

State sync invariants:

- [x] I did NOT write directly to `*.state.position`, `*.state.velocity`,
      `*.state.angle`, `*.state.turnSpeed`, or `*.state.health` outside
      `syncShipProperties` (`modules/core/src/ship/ship-manager-abstract.ts`)
      or `space-manager.ts`.

`@gameField` decorator order:

- [x] The new `@gameField('string') modelName` on `DesignState` has no other decorators, so order is trivially correct.

Remote command surface:

- [x] `modelName` lives on a `DesignState` subclass, so it is admitted by the GM design-state panel clause (category 3 in `isCommandable`). No new bare `@gameField` was introduced outside the four admission clauses.

Public API:

- [x] No new exports added to `modules/core/src/index.public.ts`.

Local verification:

- [x] `npm run test:format` — PASS
- [x] `npm run test:types` — PASS
- [x] `npm test` — 27 suites, 167 tests, all pass (2 skipped as before)

Skill / docs hygiene:

- [x] No documented behavior or skill content changed.
- [x] No new top-level singletons, unbounded caches, or globally mutable module state introduced.

## Hotspot files touched

- `modules/core/src/ship/system.ts` — added `modelName` to abstract `DesignState` base class

## Tests added or updated

- `modules/core/test/ship-manager-abstract.spec.ts` — new test: `ship systems carry the modelName configured in the ship design`

## Skills reviewed

- `starwards-colyseus`
- `starwards-tdd`

🤖 Automated by Claude Code