### PR TITLE
fix: show own cannon shells on tactical radar (closes #1002)

### DIFF
--- a/modules/browser/src/widgets/tactical-radar.ts
+++ b/modules/browser/src/widgets/tactical-radar.ts
@@ -1,5 +1,5 @@
 import { Graphics, UPDATE_PRIORITY } from 'pixi.js';
-import { ShipDriver, SpaceDriver, SpaceObject } from '@starwards/core';
+import { Projectile, ShipDriver, SpaceDriver, SpaceObject } from '@starwards/core';
 import { azimuthCircle, crosshairs, speedLines } from '../radar/tactical-radar-layers';
 import { green, radar, radarFogOfWar, radarVisibleBg } from '../colors';
 import { trackTargetObject, waitForShip } from '../ship-logic';
@@ -104,14 +104,20 @@ export async function drawTacticalRadar(
         root.addLayer(crosshairs(root, shipDriver.state, shipDriver.state.chainGun, shipTarget));
     }
     root.addLayer(speedLines(root, shipDriver.state, shipTarget));
+    // The weapons officer needs visual feedback of the shells they fire, even
+    // when the shells fly beyond normal radar-detection range. Shells owned by
+    // this ship bypass the range filter and are always shown in shell color.
+    const isOwnShell = (o: SpaceObject): o is Projectile => Projectile.isInstance(o) && o.shipId === shipDriver.id;
+    const includeInRadar = (o: SpaceObject) => rangeFilter.isInRange(o) || isOwnShell(o);
+    const getBlipColor = (s: SpaceObject) => (s.type === 'Projectile' || isOwnShell(s) ? radar.shellTint : green);
     const blipLayer = new ObjectsLayer(
         root,
         spaceDriver,
         32,
-        (s) => (s.type === 'Projectile' ? radar.shellTint : green),
+        getBlipColor,
         tacticalDrawFunctions,
         shipTarget,
-        rangeFilter.isInRange,
+        includeInRadar,
         undefined,
         undefined,
         shipDriver.state.faction,

--- a/modules/core/src/ship/chain-gun-manager.ts
+++ b/modules/core/src/ship/chain-gun-manager.ts
@@ -1,5 +1,6 @@
+import { Faction, Projectile, ScanLevel, SpaceObject, Spaceship, projectileModels } from '../space';
 import { IterationData, Updateable } from '../updateable';
-import { Projectile, SpaceObject, Spaceship, projectileModels } from '../space';
+
 import { SpaceManager, XY, calcShellSecondsToLive, capToRange, lerp } from '../logic';
 import { Vec2, gaussianRandom } from '..';
 
@@ -188,6 +189,14 @@ export class ChainGunManager implements Updateable {
                 ),
             );
             projectile.init(uniqueId('shell'), shellPosition);
+            projectile.shipId = this.spaceObject.id;
+            // Mark shells as advanced-scanned for the firing ship's faction so
+            // the weapons officer sees them with a distinct blip colour instead
+            // of the UFO/unknown tint.
+            const firingFactionIndex = Number(this.spaceObject.faction);
+            if (firingFactionIndex !== Number(Faction.NONE) && firingFactionIndex < projectile.scanLevels.length) {
+                projectile.scanLevels[firingFactionIndex] = ScanLevel.ADVANCED;
+            }
             if (projectile.design.homing) {
                 projectile.targetId = this.state.weaponsTarget.targetId;
                 projectile.secondsToLive = projectile.design.homing.secondsToLive;

--- a/modules/core/src/space/projectile.ts
+++ b/modules/core/src/space/projectile.ts
@@ -71,6 +71,13 @@ export class Projectile extends SpaceObjectBase implements Craft {
     public health = 10;
     public _explosion?: Explosion;
 
+    /**
+     * Id of the ship that fired this projectile. Empty string for projectiles
+     * not fired from a ship (e.g. test fixtures, GM-spawned).
+     */
+    @gameField('string')
+    public shipId = '';
+
     @tweakable('string')
     @gameField('string')
     public targetId: string | null = null;

--- a/modules/core/test/chain-gun-manager.spec.ts
+++ b/modules/core/test/chain-gun-manager.spec.ts
@@ -1,5 +1,14 @@
+import {
+    Faction,
+    ScanLevel,
+    ShipManagerPc,
+    SmartPilotMode,
+    SpaceManager,
+    Spaceship,
+    makeShipState,
+    shipConfigurations,
+} from '../src';
 import { MockDie, makeIterationsData } from './ship-test-harness';
-import { ShipManagerPc, SmartPilotMode, SpaceManager, Spaceship, makeShipState, shipConfigurations } from '../src';
 
 import { expect } from 'chai';
 import { switchToAvailableAmmo } from '../src/ship/chain-gun-manager';
@@ -86,6 +95,37 @@ describe('ChainGunManager', () => {
             }
 
             expect(shipMgr.state.magazine.count_CannonShell).to.be.lessThan(initialCount);
+        });
+
+        it('stamps fired projectiles with the firing ship id and advanced scan for its faction', () => {
+            const spaceMgr = new SpaceManager();
+            const shipObj = new Spaceship();
+            shipObj.id = 'ship-A';
+            shipObj.faction = Faction.Gravitas;
+            const die = new MockDie();
+            const shipMgr = new ShipManagerPc(shipObj, makeShipState(shipObj.id, dragonflyConfig), spaceMgr, die);
+            die.expectedRoll = 1;
+            spaceMgr.insert(shipObj);
+            shipMgr.setSmartPilotManeuveringMode(SmartPilotMode.DIRECT);
+            shipMgr.setSmartPilotRotationMode(SmartPilotMode.DIRECT);
+
+            const chainGun = shipMgr.state.chainGun!;
+            chainGun.isFiring = true;
+            chainGun.loadAmmo = true;
+            switchToAvailableAmmo(chainGun, shipMgr.state.magazine);
+
+            const i = makeIterationsData(2, 40);
+            for (const id of i) {
+                shipMgr.update(id);
+                spaceMgr.update(id);
+            }
+
+            const projectiles = [...spaceMgr.state.getAll('Projectile')];
+            expect(projectiles.length).to.be.greaterThan(0);
+            for (const p of projectiles) {
+                expect(p.shipId).to.equal(shipObj.id);
+                expect(p.scanLevels[Faction.Gravitas as number]).to.equal(ScanLevel.ADVANCED);
+            }
         });
 
         it('does not fire when effectiveness is zero', () => {


### PR DESCRIPTION
Closes #1002

## Summary

The weapons officer could not see the shells they fired on the tactical radar:

- Shells travelling beyond the radar-equation detection threshold (~1600 m) were invisible, even though a chain-gun commonly engages targets further out.
- Shells within detection range were rendered with the UFO tint because `Projectile` has no faction and its `scanLevels` default to `UFO`, so the `radar.shellTint` getColor was overridden to `radar.unknownTint` by the scan-level guard in `ObjectsLayer`.

## Changes

- **`modules/core/src/space/projectile.ts`**: added `@gameField('string') shipId = ''` to `Projectile` so each fired shell carries its owner's ship id (syncs to clients via Colyseus).
- **`modules/core/src/ship/chain-gun-manager.ts`**: stamps `projectile.shipId = this.spaceObject.id` when firing, and bumps `projectile.scanLevels[firingFaction] = ScanLevel.ADVANCED` so same-faction viewers see the shell with a recognizable colour instead of the unknown tint.
- **`modules/browser/src/widgets/tactical-radar.ts`**: composes the existing range filter with an "own-shell" bypass — any `Projectile` whose `shipId` matches the local ship is always included in the radar view and always coloured `radar.shellTint`.

GM radar already showed all projectiles in white (no range filter, no faction-based scan check), so no change was needed there.

## MUST fill in (do not delete this section)

State sync invariants:

- [x] I did NOT write directly to `*.state.position`, `*.state.velocity`,
      `*.state.angle`, `*.state.turnSpeed`, or `*.state.health` outside
      `syncShipProperties` (`modules/core/src/ship/ship-manager-abstract.ts`)
      or `space-manager.ts`.

`@gameField` decorator order:

- [x] The new `@gameField('string') shipId` on `Projectile` has no other
      decorators, so order is trivially correct.

Remote command surface:

- [x] `shipId` is set only on the server by `ChainGunManager` — it is not
      a remote command target. No `@commandable`/`@tweakable` added.

Public API:

- [x] No new exports to `modules/core/src/index.public.ts`. `Projectile`,
      `Faction`, and `ScanLevel` were already exported.

Local verification:

- [x] `npm run test:format` — PASS
- [x] `npm run test:types` — PASS
- [x] `npm test` — 28 suites, 173 tests pass (2 skipped as before)

Skill / docs hygiene:

- [x] No documented behavior or skill content changed.
- [x] No new top-level singletons, unbounded caches, or globally mutable
      module state introduced.

## Hotspot files touched

- `modules/core/src/ship/chain-gun-manager.ts` — added `shipId` stamping and scan-level bump in `fireChainGun()`

## Tests added or updated

- `modules/core/test/chain-gun-manager.spec.ts` — new test: `stamps fired projectiles with the firing ship id and advanced scan for its faction`

## Skills reviewed

- `starwards-colyseus` (new `@gameField` on a synced `SpaceObject`)
- `starwards-tdd` (wrote the test alongside the fix)

🤖 Automated by Claude Code