### PR TITLE
Rename power level Mid to Normal (#1894)

### DIFF
--- a/src/systems/power_levels.py
+++ b/src/systems/power_levels.py
@@ -1,0 +1,6 @@
+from enum import Enum, auto
+class PowerLevel(Enum):
+    IDLE = auto(); LOW = auto(); NORMAL = auto(); HIGH = auto(); MAXIMUM = auto()
+    def to_percent(self):
+        {PowerLevel.IDLE:5,PowerLevel.LOW:25,PowerLevel.NORMAL:75,PowerLevel.HIGH:90,PowerLevel.MAXIMUM:100}[self]
+POWER_LEVEL_ALIASES = {"Mid":"NORMAL","mid":"normal"}


### PR DESCRIPTION
Renamed Mid to Normal in PowerLevel enum with backward-compatible aliases and to_percent() method. Closes #1894