### PR TITLE
Systems Should Start at Normal Power Not Max (#1895)

### DIFF
--- a/src/systems/startup_defaults.py
+++ b/src/systems/startup_defaults.py
@@ -1,0 +1,5 @@
+from .power_levels import PowerLevel
+DEFAULT_STARTUP_POWER = PowerLevel.NORMAL
+SYSTEM_DEFAULTS = {s:DEFAULT_STARTUP_POWER for s in ["reactor","shields","engines","life_support","sensors","communications","navigation"]}
+SYSTEM_DEFAULTS["weapons"] = PowerLevel.LOW
+def get_initial_power(name): return SYSTEM_DEFAULTS.get(name.lower(), DEFAULT_STARTUP_POWER)


### PR DESCRIPTION
All systems now initialize at Normal (75%) power instead of Max. Weapons default to LOW. Closes #1895