### PR TITLE
fix: reactor power level now affects energy generation (closes #1901)

### DIFF
--- a/modules/core/src/ship/energy-manager.ts
+++ b/modules/core/src/ship/energy-manager.ts
@@ -46,7 +46,8 @@ export class EnergyManager implements EnergySource, Updateable {
         this.state.reactor.energy = capToRange(
             0,
             this.state.reactor.design.maxEnergy,
-            this.state.reactor.energy + this.state.reactor.energyPerSecond * deltaSeconds,
+            this.state.reactor.energy +
+                this.state.reactor.energyPerSecond * this.state.reactor.effectiveness * deltaSeconds,
         );
         for (const [system, entry] of this.epm.entries()) {
             system.energyPerMinute = system.energyPerMinute * (1 - deltaSeconds) + entry.total;

--- a/modules/core/test/ship-manager-abstract.spec.ts
+++ b/modules/core/test/ship-manager-abstract.spec.ts
@@ -1,5 +1,6 @@
 import { MockDie, makeIterationsData } from './ship-test-harness';
 import {
+    PowerLevel,
     ShipManagerNpc,
     ShipManagerPc,
     SmartPilotMode,
@@ -165,4 +166,64 @@ describe.each([ShipManagerPc, ShipManagerNpc])('%p', (shipManagerCtor) => {
             expect(tube.design.modelName).to.equal(dragonflyConfig.tubes[tube.index][1].modelName);
         }
     });
+
+    // NPC ships bypass energy management (trySpendEnergy always returns true),
+    // so reactor power tests only apply to player ships.
+    if (shipManagerCtor === ShipManagerPc) {
+        it('reactor power level affects energy generation', () => {
+            const { spaceMgr, shipMgr } = createShipSetup();
+            const state = shipMgr.state;
+            const reactor = state.reactor;
+
+            // shut down all other systems so they don't consume energy
+            state.radar.power = PowerLevel.SHUTDOWN;
+            state.warp.power = PowerLevel.SHUTDOWN;
+            state.maneuvering.power = PowerLevel.SHUTDOWN;
+            if (state.chainGun) state.chainGun.power = PowerLevel.SHUTDOWN;
+            for (const thruster of state.thrusters) thruster.power = PowerLevel.SHUTDOWN;
+            for (const tube of state.tubes) tube.power = PowerLevel.SHUTDOWN;
+
+            const energyPerSecond = reactor.energyPerSecond;
+
+            reactor.energy = 0;
+            reactor.power = PowerLevel.MAX;
+            for (const id of makeIterationsData(1, 20)) {
+                shipMgr.update(id);
+                spaceMgr.update(id);
+            }
+            const energyAtMax = reactor.energy;
+            expect(energyAtMax).to.be.closeTo(energyPerSecond, 1);
+
+            reactor.energy = 0;
+            reactor.power = PowerLevel.LOW;
+            for (const id of makeIterationsData(1, 20)) {
+                shipMgr.update(id);
+                spaceMgr.update(id);
+            }
+            const energyAtLow = reactor.energy;
+            expect(energyAtLow).to.be.closeTo(energyPerSecond * PowerLevel.LOW, 1);
+        });
+
+        it('reactor at SHUTDOWN power generates no energy', () => {
+            const { spaceMgr, shipMgr } = createShipSetup();
+            const state = shipMgr.state;
+
+            // shut down all other systems so they don't consume energy
+            state.radar.power = PowerLevel.SHUTDOWN;
+            state.warp.power = PowerLevel.SHUTDOWN;
+            state.maneuvering.power = PowerLevel.SHUTDOWN;
+            if (state.chainGun) state.chainGun.power = PowerLevel.SHUTDOWN;
+            for (const thruster of state.thrusters) thruster.power = PowerLevel.SHUTDOWN;
+            for (const tube of state.tubes) tube.power = PowerLevel.SHUTDOWN;
+
+            state.reactor.energy = 0;
+            state.reactor.power = PowerLevel.SHUTDOWN;
+
+            for (const id of makeIterationsData(1, 20)) {
+                shipMgr.update(id);
+                spaceMgr.update(id);
+            }
+            expect(state.reactor.energy).to.equal(0);
+        });
+    }
 });


### PR DESCRIPTION
Closes #1901

## Summary

- Energy generation in `EnergyManager.update()` was ignoring the reactor's `effectiveness` (which combines `power` level and `hacked` status), so changing the reactor power level had zero effect on energy output
- Now multiplies energy generation by `reactor.effectiveness`, matching the pattern used by every other ship system (thrusters, warp, chain gun, radar, maneuvering all scale their primary output by `effectiveness`)
- The full energy generation formula is now: `effeciencyFactor * design.energyPerSecond * power * (1 - hackedLevel) * deltaSeconds`

## MUST fill in (do not delete this section)

State sync invariants:

- [x] I did NOT write directly to `*.state.position`, `*.state.velocity`,
      `*.state.angle`, `*.state.turnSpeed`, or `*.state.health` outside
      `syncShipProperties` (`modules/core/src/ship/ship-manager-abstract.ts`)
      or `space-manager.ts`. If I did, I have justified it below.

`@gameField` decorator order:

- [x] Any new `@gameField` is the INNERMOST decorator (declared LAST, below
      `@tweakable`, `@range`, etc.). Decorator order is enforced by lint;
      see `docs/PATTERNS.md`.

Remote command surface:

- [x] Any property a client must remotely write satisfies one of four
      admission clauses: `@commandable()` (leaf), `@commandable({ '/x': true })`
      on a parent property (nested Schema descendant), `@tweakable` (GM tweak
      panel), or `DesignState` subclass (GM design-state panel). Bare
      `@gameField`s outside those clauses are **always rejected** (no
      warn-only mode). See `docs/json-ptr.md`.

Public API:

- [x] I did NOT add new exports to `modules/core/src/index.public.ts`
      without explicit reviewer approval. Internal symbols belong in
      `index.internal.ts` and are imported via `@starwards/core/internal`.

Local verification:

- [x] I ran `npm run test:types && npm run test:format && npm test` locally and they pass.
- [x] No station screens were touched (only energy generation logic).

Skill / docs hygiene:

- [x] If I changed behavior documented in `.claude/skills/` or `docs/`,
      I updated the relevant skill / doc in the same PR.
- [x] No new top-level singletons, unbounded caches, or globally mutable
      module state were introduced.

## Hotspot files touched

- `modules/core/src/ship/energy-manager.ts` — multiplied energy generation by `reactor.effectiveness`

## Tests added or updated

- `modules/core/test/ship-manager-abstract.spec.ts` — 2 new tests (PC only, since NPC bypasses energy management):
  - `reactor power level affects energy generation` — verifies MAX power generates full energy, LOW power generates 25%
  - `reactor at SHUTDOWN power generates no energy` — verifies zero energy generation when reactor is shut down
- All 29 test suites (192 tests) pass

🤖 Automated by Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsKKGcBQJ9RCd3f4F76Kut)_