### PR TITLE
fix: add stabilization phase to rotationFromTargetTurnSpeed test (closes #1434)

### DIFF
--- a/modules/core/test/helm-assist.spec.ts
+++ b/modules/core/test/helm-assist.spec.ts
@@ -80,11 +80,21 @@ describe('helm assist', function () {
                         rotation: () => harness.shipState.rotation,
                         turnSpeed: () => harness.shipState.turnSpeed,
                     });
-                    harness.simulate(metrics.timeToReach, metrics.iterations, (time: number) => {
+                    const iteration = (time: number) => {
                         const rotation = rotationFromTargetTurnSpeed(time, harness.shipState, 0);
                         harness.shipMgr.state.smartPilot.rotation = rotation;
-                    });
-                    expect(limitPercision(harness.shipObj.turnSpeed)).to.be.closeTo(0, metrics.errorMargin);
+                    };
+                    harness.simulate(metrics.timeToReach, metrics.iterations, iteration);
+                    harness.annotateGraph('test turnSpeed');
+                    expect(limitPercision(harness.shipObj.turnSpeed), 'turnSpeed').to.be.closeTo(
+                        0,
+                        metrics.errorMargin,
+                    );
+                    harness.simulate(metrics.timeToReach, metrics.iterations, iteration);
+                    expect(limitPercision(harness.shipObj.turnSpeed), 'turnSpeed after stabling').to.be.closeTo(
+                        0,
+                        metrics.stabilizationErrorMargin,
+                    );
                 }),
             );
         });


### PR DESCRIPTION
Closes #1434

## Summary

- The `rotationFromTargetTurnSpeed` property test was the only helm-assist test missing a stabilization phase (second `simulate` pass), making it vulnerable to edge cases where the quadratic control response in `accelerateToSpeed` (`res * res * sign(res)`) converged slowly
- Added a second simulation pass with `stabilizationErrorMargin` check, aligning the test with the pattern used by `matchGlobalSpeed` and `moveToTarget` tests
- Added `annotateGraph` call and assertion labels for consistency with other tests

## Investigation

- Reproduced the original failing seed (`-1100181686`) — it now passes
- Ran 10,000 fast-check iterations for `rotationFromTargetTurnSpeed` — all pass
- Ran 5,000 fast-check iterations for `moveToTarget` (related #1459) — all pass
- The original flakiness was likely resolved by subsequent refactors (ShipState composition in #1877, ShipDie deterministic hashing in #1891), but the test structure was still weaker than its siblings

## MUST fill in (do not delete this section)

State sync invariants:

- [x] I did NOT write directly to `*.state.position`, `*.state.velocity`,
      `*.state.angle`, `*.state.turnSpeed`, or `*.state.health` outside
      `syncShipProperties` (`modules/core/src/ship/ship-manager-abstract.ts`)
      or `space-manager.ts`. If I did, I have justified it below.

`@gameField` decorator order:

- [x] Any new `@gameField` is the INNERMOST decorator (declared LAST, below
      `@tweakable`, `@range`, etc.). Decorator order is enforced by lint;
      see `docs/PATTERNS.md`.

Remote command surface:

- [x] Any property a client must remotely write satisfies one of four
      admission clauses: `@commandable()` (leaf), `@commandable({ '/x': true })`
      on a parent property (nested Schema descendant), `@tweakable` (GM tweak
      panel), or `DesignState` subclass (GM design-state panel). Bare
      `@gameField`s outside those clauses are **always rejected** (no
      warn-only mode). See `docs/json-ptr.md`.

Public API:

- [x] I did NOT add new exports to `modules/core/src/index.public.ts`
      without explicit reviewer approval. Internal symbols belong in
      `index.internal.ts` and are imported via `@starwards/core/internal`.

Local verification:

- [x] I ran `npm run test:types && npm run test:format && npm test` locally and they pass.
- [x] No station screens were touched (only a test file).

Skill / docs hygiene:

- [x] If I changed behavior documented in `.claude/skills/` or `docs/`,
      I updated the relevant skill / doc in the same PR.
- [x] No new top-level singletons, unbounded caches, or globally mutable
      module state were introduced.

## Hotspot files touched

- `modules/core/test/helm-assist.spec.ts` — added stabilization phase to `rotationFromTargetTurnSpeed` test

## Tests added or updated

- `modules/core/test/helm-assist.spec.ts` — enhanced `rotationFromTargetTurnSpeed` test with two-phase convergence + stability check
- All 29 test suites (188 tests) pass

🤖 Automated by Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_0194jMocArhAtiY6afcjuu7t)_