### PR TITLE
fix: use PD control in accelerateToPosition pinpoint region (closes #1459)

### DIFF
--- a/modules/core/src/logic/helm-assist.ts
+++ b/modules/core/src/logic/helm-assist.ts
@@ -73,9 +73,11 @@ function accelerateToPosition(deltaSeconds: number, capacity: number, velocity: 
 
     if (absVelocity < pinPointVelocity * 0.5) {
         const stopDistance = whereWillItStop(0, absVelocity, -capacity);
-        if (targetDistance < stopDistance * 2) {
-            const controlStrength = targetDistance / (stopDistance * 2);
-            return capToRange(-1, 1, controlStrength) * signRelTarget;
+        const controlDistance = Math.max(stopDistance * 2, pinPointDistance);
+        if (targetDistance < controlDistance) {
+            const positionControl = (targetDistance / controlDistance) * signRelTarget;
+            const velocityDamping = velocity / pinPointVelocity;
+            return capToRange(-1, 1, positionControl - velocityDamping);
         }
     }
 


### PR DESCRIPTION
Closes #1459

## Summary

- The `accelerateToPosition` pinpoint control region had a gap at near-zero velocity: `stopDistance` collapsed to ~0, shrinking the region to nothing, so the "wrong direction" check applied full-thrust impulses that created oscillation cycles near the target
- Extended the pinpoint region to at least `pinPointDistance` (the minimum meaningful distance for the discrete control loop) and replaced pure proportional control with proportional-derivative control: position drives toward target, velocity component damps overshoot
- This eliminates the steady-state oscillation that caused the flaky test — the ship now converges smoothly to the target instead of bouncing around it

## Investigation

- The original failure (`seed: 1236377626`, counterexample `[-552.88, 0.5]`) was caused by the old `sqrtErrorMargin` formula being too tight (`sqrt(distance * 0.05) ≈ 5.26` vs actual offset of 5.5)
- The November 2025 margin update ("add more slack") widened the margin enough that the test passes 10,000 iterations even without this fix
- This PR fixes the root cause (control algorithm oscillation) rather than just tolerating it via wider margins
- Ran 10,000 fast-check iterations for both `moveToTarget` tests — all pass

## MUST fill in (do not delete this section)

State sync invariants:

- [x] I did NOT write directly to `*.state.position`, `*.state.velocity`,
      `*.state.angle`, `*.state.turnSpeed`, or `*.state.health` outside
      `syncShipProperties` (`modules/core/src/ship/ship-manager-abstract.ts`)
      or `space-manager.ts`. If I did, I have justified it below.

`@gameField` decorator order:

- [x] Any new `@gameField` is the INNERMOST decorator (declared LAST, below
      `@tweakable`, `@range`, etc.). Decorator order is enforced by lint;
      see `docs/PATTERNS.md`.

Remote command surface:

- [x] Any property a client must remotely write satisfies one of four
      admission clauses: `@commandable()` (leaf), `@commandable({ '/x': true })`
      on a parent property (nested Schema descendant), `@tweakable` (GM tweak
      panel), or `DesignState` subclass (GM design-state panel). Bare
      `@gameField`s outside those clauses are **always rejected** (no
      warn-only mode). See `docs/json-ptr.md`.

Public API:

- [x] I did NOT add new exports to `modules/core/src/index.public.ts`
      without explicit reviewer approval. Internal symbols belong in
      `index.internal.ts` and are imported via `@starwards/core/internal`.

Local verification:

- [x] I ran `npm run test:types && npm run test:format && npm test` locally and they pass.
- [x] No station screens were touched (only internal control algorithm).

Skill / docs hygiene:

- [x] If I changed behavior documented in `.claude/skills/` or `docs/`,
      I updated the relevant skill / doc in the same PR.
- [x] No new top-level singletons, unbounded caches, or globally mutable
      module state were introduced.

## Hotspot files touched

- `modules/core/src/logic/helm-assist.ts` — improved pinpoint control in `accelerateToPosition`

## Tests added or updated

- No new tests needed — this fixes the control algorithm that the existing property-based tests exercise. All 29 test suites (190 tests) pass.

🤖 Automated by Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7oWpfNj62zUcp8SvmK3VP)_