### PR TITLE
fix: default system power to Normal instead of Max (closes #1895)

### DIFF
--- a/modules/core/src/ship/system.ts
+++ b/modules/core/src/ship/system.ts
@@ -96,7 +96,7 @@ export abstract class SystemState extends Schema {
     @tweakable({ type: 'enum', enum: PowerLevel })
     @commandable()
     @gameField('float32')
-    public power = PowerLevel.MAX;
+    public power = PowerLevel.NORMAL;
 
     @range([0, 1])
     @tweakable({ type: 'enum', enum: HackLevel })

--- a/modules/core/test/ship-manager.spec.ts
+++ b/modules/core/test/ship-manager.spec.ts
@@ -2,6 +2,7 @@ import {
     Asteroid,
     EPSILON,
     Explosion,
+    PowerLevel,
     ShipManagerNpc,
     ShipManagerPc,
     SmartPilotMode,
@@ -101,6 +102,7 @@ describe.each([ShipManagerPc, ShipManagerNpc])('%p', (shipManagerCtor) => {
                 spaceMgr.insert(shipObj);
                 shipMgr.setSmartPilotManeuveringMode(SmartPilotMode.DIRECT);
                 shipMgr.setSmartPilotRotationMode(SmartPilotMode.DIRECT);
+                for (const s of shipMgr.state.systems()) s.power = PowerLevel.MAX;
                 shipMgr.state.chainGun!.isFiring = true;
                 switchToAvailableAmmo(shipMgr.state.chainGun!, shipMgr.state.magazine);
 
@@ -139,6 +141,7 @@ describe.each([ShipManagerPc, ShipManagerNpc])('%p', (shipManagerCtor) => {
                     spaceMgr.insert(shipObj);
                     shipMgr.setSmartPilotManeuveringMode(SmartPilotMode.DIRECT);
                     shipMgr.setSmartPilotRotationMode(SmartPilotMode.DIRECT);
+                    for (const s of shipMgr.state.systems()) s.power = PowerLevel.MAX;
                     shipMgr.state.chainGun!.rateOfFireFactor = 1;
                     shipMgr.state.chainGun!.design.use_BlastCannonShell = false;
                     shipMgr.state.chainGun!.design.use_Missile = false;
@@ -215,6 +218,7 @@ describe.each([ShipManagerPc, ShipManagerNpc])('%p', (shipManagerCtor) => {
                     spaceMgr.insert(shipObj);
                     shipMgr.setSmartPilotManeuveringMode(SmartPilotMode.DIRECT);
                     shipMgr.setSmartPilotRotationMode(SmartPilotMode.DIRECT);
+                    for (const s of shipMgr.state.systems()) s.power = PowerLevel.MAX;
                     shipMgr.state.chainGun!.rateOfFireFactor = 0.5;
                     shipMgr.state.chainGun!.design.bulletsPerSecond = bulletsPerSecond;
                     shipMgr.state.chainGun!.isFiring = true;

--- a/modules/core/test/ship-test-harness.ts
+++ b/modules/core/test/ship-test-harness.ts
@@ -2,6 +2,7 @@ import { GraphPointInput, PlotlyGraphBuilder } from './ploty-graph-builder';
 import {
     Iterator,
     MAX_SAFE_FLOAT,
+    PowerLevel,
     ShipManagerPc,
     SmartPilotMode,
     SpaceManager,
@@ -196,6 +197,9 @@ export class ShipTestHarness {
         global.harness = this;
         this.shipMgr.setSmartPilotManeuveringMode(SmartPilotMode.DIRECT);
         this.shipMgr.setSmartPilotRotationMode(SmartPilotMode.DIRECT);
+        for (const system of this.shipMgr.state.systems()) {
+            system.power = PowerLevel.MAX;
+        }
     }
 
     get shipState() {

--- a/modules/core/test/signals-job-manager.spec.ts
+++ b/modules/core/test/signals-job-manager.spec.ts
@@ -1,6 +1,7 @@
 import {
     Faction,
     HackLevel,
+    PowerLevel,
     ScanLevel,
     ShipManagerPc,
     SmartPilotMode,
@@ -30,6 +31,7 @@ function createTestSetup() {
     spaceMgr.insert(shipObj);
     shipMgr.setSmartPilotManeuveringMode(SmartPilotMode.DIRECT);
     shipMgr.setSmartPilotRotationMode(SmartPilotMode.DIRECT);
+    for (const s of shipMgr.state.systems()) s.power = PowerLevel.MAX;
 
     // Create a target ship within radar range
     const targetObj = new Spaceship();


### PR DESCRIPTION
Closes #1895

## Summary

- Changed `SystemState.power` default from `PowerLevel.MAX` (1.0) to `PowerLevel.NORMAL` (0.5) in `modules/core/src/ship/system.ts`
- All ship systems (reactor, radar, chaingun, maneuvering, warp, signals, etc.) inherit this default, so they now start at Normal power
- Updated tests that depend on full power effectiveness to explicitly set `PowerLevel.MAX`, making their assumptions visible

## MUST fill in (do not delete this section)

State sync invariants:

- [x] I did NOT write directly to `*.state.position`, `*.state.velocity`,
      `*.state.angle`, `*.state.turnSpeed`, or `*.state.health` outside
      `syncShipProperties` (`modules/core/src/ship/ship-manager-abstract.ts`)
      or `space-manager.ts`. If I did, I have justified it below.

`@gameField` decorator order:

- [x] Any new `@gameField` is the INNERMOST decorator (declared LAST, below
      `@tweakable`, `@range`, etc.). Decorator order is enforced by lint;
      see `docs/PATTERNS.md`.

Remote command surface:

- [x] Any property a client must remotely write satisfies one of four
      admission clauses: `@commandable()` (leaf), `@commandable({ '/x': true })`
      on a parent property (nested Schema descendant), `@tweakable` (GM tweak
      panel), or `DesignState` subclass (GM design-state panel). Bare
      `@gameField`s outside those clauses are **always rejected** (no
      warn-only mode). See `docs/json-ptr.md`.

Public API:

- [x] I did NOT add new exports to `modules/core/src/index.public.ts`
      without explicit reviewer approval. Internal symbols belong in
      `index.internal.ts` and are imported via `@starwards/core/internal`.

Local verification:

- [x] I ran `npm run test:types && npm run test:format && npm test` locally and they pass.
- [x] No station screens were touched (only core system default + test files).

Skill / docs hygiene:

- [x] If I changed behavior documented in `.claude/skills/` or `docs/`,
      I updated the relevant skill / doc in the same PR.
- [x] No new top-level singletons, unbounded caches, or globally mutable
      module state were introduced.

## Hotspot files touched

- `modules/core/src/ship/system.ts` — changed default power from MAX to NORMAL

## Tests added or updated

- `modules/core/test/ship-test-harness.ts` — `ShipTestHarness` constructor now sets all systems to MAX power for test consistency
- `modules/core/test/ship-manager.spec.ts` — 3 chaingun tests explicitly set systems to MAX power
- `modules/core/test/signals-job-manager.spec.ts` — `createTestSetup` sets systems to MAX power
- All 30 test suites (230 tests) pass

🤖 Automated by Claude Code
https://claude.ai/code/session_01L2P9amKta43up1ZSM7rKma

---
_Generated by [Claude Code](https://claude.ai/code/session_01L2P9amKta43up1ZSM7rKma)_