### PR TITLE
feat: add waypoint placement to Signal station (closes #1893)

### DIFF
--- a/modules/browser/src/radar/waypoint-placement-layer.ts
+++ b/modules/browser/src/radar/waypoint-placement-layer.ts
@@ -1,4 +1,4 @@
-import { Container, FederatedPointerEvent, Rectangle } from 'pixi.js';
+import { Circle, Container, FederatedPointerEvent } from 'pixi.js';
 import { SpaceDriver, spaceCommands } from '@starwards/core';
 
 import { CameraView } from './camera-view';
@@ -12,11 +12,15 @@ export class WaypointPlacementLayer {
         private spaceDriver: SpaceDriver,
     ) {
         this.stage.interactive = true;
-        this.stage.hitArea = new Rectangle(0, 0, parent.renderer.width, parent.renderer.height);
+        this.stage.hitArea = this.circleHitArea();
         parent.events.on('screenChanged', () => {
-            this.stage.hitArea = new Rectangle(0, 0, parent.renderer.width, parent.renderer.height);
+            this.stage.hitArea = this.circleHitArea();
         });
         this.stage.on('pointerup', this.onPointerup);
+    }
+
+    private circleHitArea() {
+        return new Circle(this.parent.renderer.width / 2, this.parent.renderer.height / 2, this.parent.radius);
     }
 
     get renderRoot(): Container {

--- a/modules/browser/src/radar/waypoint-placement-layer.ts
+++ b/modules/browser/src/radar/waypoint-placement-layer.ts
@@ -1,0 +1,50 @@
+import { Container, FederatedPointerEvent, Rectangle } from 'pixi.js';
+import { SpaceDriver, spaceCommands } from '@starwards/core';
+
+import { CameraView } from './camera-view';
+
+export class WaypointPlacementLayer {
+    private stage = new Container();
+    private active = false;
+
+    constructor(
+        private parent: CameraView,
+        private spaceDriver: SpaceDriver,
+    ) {
+        this.stage.interactive = true;
+        this.stage.hitArea = new Rectangle(0, 0, parent.renderer.width, parent.renderer.height);
+        parent.events.on('screenChanged', () => {
+            this.stage.hitArea = new Rectangle(0, 0, parent.renderer.width, parent.renderer.height);
+        });
+        this.stage.on('pointerup', this.onPointerup);
+    }
+
+    get renderRoot(): Container {
+        return this.stage;
+    }
+
+    activate() {
+        this.active = true;
+        this.stage.cursor = 'cell';
+    }
+
+    deactivate() {
+        this.active = false;
+        this.stage.cursor = 'default';
+    }
+
+    toggle() {
+        if (this.active) {
+            this.deactivate();
+        } else {
+            this.activate();
+        }
+    }
+
+    private onPointerup = (event: FederatedPointerEvent) => {
+        if (!this.active) return;
+        const position = this.parent.screenToWorld(event.global);
+        this.spaceDriver.command(spaceCommands.createWaypointOrder, { position });
+        this.deactivate();
+    };
+}

--- a/modules/browser/src/screens/signals.ts
+++ b/modules/browser/src/screens/signals.ts
@@ -8,6 +8,7 @@ import ElementQueries from 'css-element-queries/src/ElementQueries';
 import EventEmitter from 'eventemitter3';
 import { InputManager } from '../input/input-manager';
 import { SelectionContainer } from '../radar/selection-container';
+import { WaypointPlacementLayer } from '../radar/waypoint-placement-layer';
 import { drawLongRangeRadar } from '../widgets/long-range-radar';
 import { drawSystemsStatus } from '../widgets/system-status';
 import { drawTargetInfo } from '../widgets/target-info';
@@ -51,14 +52,24 @@ async function initScreen(driver: Driver, shipId: string) {
     const stationTarget = new SelectionContainer().init(spaceDriver);
     const zoomEvents = new EventEmitter<ZoomEvent>();
 
-    await drawLongRangeRadar(spaceDriver, shipDriver, container, { range: 50_000 }, zoomEvents, stationTarget);
+    const radarView = await drawLongRangeRadar(
+        spaceDriver,
+        shipDriver,
+        container,
+        { range: 50_000 },
+        zoomEvents,
+        stationTarget,
+    );
+    const waypointLayer = new WaypointPlacementLayer(radarView, spaceDriver);
+    radarView.addLayer(waypointLayer.renderRoot);
+
     drawTargetInfo(container.subContainer(VPos.TOP, HPos.LEFT), spaceDriver, shipDriver, stationTarget);
     drawSystemsStatus(
         container.subContainer(VPos.TOP, HPos.RIGHT),
         shipDriver,
         shipDriver.systems.filter((s) => s.pointer === '/radar'),
     );
-    wireInput(spaceDriver, shipId, stationTarget, zoomEvents);
+    wireInput(spaceDriver, shipId, stationTarget, zoomEvents, waypointLayer);
 }
 
 function wireInput(
@@ -66,6 +77,7 @@ function wireInput(
     shipId: string,
     stationTarget: SelectionContainer,
     zoomEvents: EventEmitter<ZoomEvent>,
+    waypointLayer: WaypointPlacementLayer,
 ) {
     let currentIndex = -1;
 
@@ -102,6 +114,7 @@ function wireInput(
     );
     input.addClickAction(() => zoomEvents.emit('zoomIn'), '=', 'Zoom In');
     input.addClickAction(() => zoomEvents.emit('zoomOut'), '-', 'Zoom Out');
+    input.addClickAction(() => waypointLayer.toggle(), 'w', 'Place Waypoint');
     input.init();
     setupHotkeyHelp(input);
 }

--- a/modules/e2e/test/signals-screen.spec.ts
+++ b/modules/e2e/test/signals-screen.spec.ts
@@ -36,13 +36,11 @@ test.describe('Signals Screen', () => {
         await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
 
         // Wait for waypoint to appear in server space state
-        const startTime = Date.now();
-        let waypoints: unknown[] = [];
-        while (Date.now() - startTime < 3000) {
-            waypoints = [...gameDriver.gameManager.spaceManager.state.getAll('Waypoint')];
-            if (waypoints.length > 0) break;
-            await new Promise((resolve) => setTimeout(resolve, 50));
-        }
-        expect(waypoints.length).toBeGreaterThan(0);
+        await expect
+            .poll(() => [...gameDriver.gameManager.spaceManager.state.getAll('Waypoint')].length, {
+                timeout: 3000,
+                message: 'expected at least one waypoint to be created',
+            })
+            .toBeGreaterThan(0);
     });
 });

--- a/modules/e2e/test/signals-screen.spec.ts
+++ b/modules/e2e/test/signals-screen.spec.ts
@@ -1,0 +1,48 @@
+import { cleanupPageState, navigateToScreen, setupPageErrorHandlers } from './test-infrastructure';
+import { expect, test } from '@playwright/test';
+import { makeDriver } from './driver';
+
+import { maps } from '@starwards/server';
+
+const { single_ship } = maps;
+const shipId = single_ship.testShipId;
+const gameDriver = makeDriver(test);
+
+test.describe('Signals Screen', () => {
+    test.beforeEach(async ({ page }) => {
+        setupPageErrorHandlers(page);
+        await gameDriver.gameManager.startGame(single_ship);
+        await navigateToScreen(page, `/signals.html?ship=${shipId}`, { baseURL: gameDriver.baseURL });
+    });
+
+    test.afterEach(async ({ page }) => {
+        await cleanupPageState(page);
+    });
+
+    test('displays long range radar', async ({ page }) => {
+        await expect(page.locator('[data-id="Long Range Radar"]')).toBeVisible({ timeout: 10000 });
+    });
+
+    test('places waypoint when W is pressed and radar is clicked', async ({ page }) => {
+        const radar = page.locator('[data-id="Long Range Radar"]');
+        await expect(radar).toBeVisible({ timeout: 10000 });
+
+        // Press W to enter waypoint placement mode
+        await page.keyboard.press('w');
+
+        // Click the center of the radar
+        const box = await radar.boundingBox();
+        if (!box) throw new Error('Radar canvas not found');
+        await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+
+        // Wait for waypoint to appear in server space state
+        const startTime = Date.now();
+        let waypoints: unknown[] = [];
+        while (Date.now() - startTime < 3000) {
+            waypoints = [...gameDriver.gameManager.spaceManager.state.getAll('Waypoint')];
+            if (waypoints.length > 0) break;
+            await new Promise((resolve) => setTimeout(resolve, 50));
+        }
+        expect(waypoints.length).toBeGreaterThan(0);
+    });
+});


### PR DESCRIPTION
Closes #1893

## Summary

- Signal operators can press **`w`** to enter waypoint placement mode, then click the long-range radar to drop a waypoint at that world position
- New `WaypointPlacementLayer` PixiJS class handles the click-to-place interaction; wired into `signals.ts` via `InputManager`
- Waypoints placed by Signal immediately appear on the Pilot's radar (pilot-radar already renders all in-range waypoints)

## MUST fill in (do not delete this section)

State sync invariants:

- [x] I did NOT write directly to `*.state.position`, `*.state.velocity`,
      `*.state.angle`, `*.state.turnSpeed`, or `*.state.health` outside
      `syncShipProperties` (`modules/core/src/ship/ship-manager-abstract.ts`)
      or `space-manager.ts`. If I did, I have justified it below.

`@gameField` decorator order:

- [x] Any new `@gameField` is the INNERMOST decorator (declared LAST, below
      `@tweakable`, `@range`, etc.). Decorator order is enforced by lint;
      see `docs/PATTERNS.md`. (No new `@gameField` introduced in this PR.)

Remote command surface:

- [x] Any property a client must remotely write satisfies one of four
      admission clauses: `@commandable()` (leaf), `@commandable({ '/x': true })`
      on a parent property (nested Schema descendant), `@tweakable` (GM tweak
      panel), or `DesignState` subclass (GM design-state panel). Bare
      `@gameField`s outside those clauses are **always rejected** (no
      warn-only mode). See `docs/json-ptr.md`. (Uses existing `createWaypointOrder` command — no new command surface.)

Public API:

- [x] I did NOT add new exports to `modules/core/src/index.public.ts`
      without explicit reviewer approval. Internal symbols belong in
      `index.internal.ts` and are imported via `@starwards/core/internal`.

Local verification:

- [x] I ran `npm run test:static && npm test` locally and they pass.
- [x] If I touched a station screen, I ran the relevant E2E spec under
      `modules/e2e/test/` locally. (New `signals-screen.spec.ts` passes; all 32 E2E tests pass.)

Skill / docs hygiene:

- [x] If I changed behavior documented in `.claude/skills/` or `docs/`,
      I updated the relevant skill / doc in the same PR. (No existing skill/doc covers this feature.)
- [x] No new top-level singletons, unbounded caches, or globally mutable
      module state were introduced. (`WaypointPlacementLayer` is instantiated per screen-load, not globally.)

## Hotspot files touched

none

## Tests added or updated

- `modules/e2e/test/signals-screen.spec.ts` — new file: two tests (radar visible, waypoint placement via W+click)

## Skills reviewed

- `starwards-tdd`, `starwards-verification`, `starwards-autonomous`, `starwards-station-ui`

🤖 Automated by Claude Code
https://claude.ai/code/session_0199tunNcLnsbLJaomYWKKcs