### PR TITLE
fix: clear currentTask in resetShipState after NPC→PC conversion (closes #1847)

### DIFF
--- a/modules/core/src/ship/ship-manager-abstract.ts
+++ b/modules/core/src/ship/ship-manager-abstract.ts
@@ -65,11 +65,12 @@ export function resetShipState(state: ShipState) {
     state.rotationModeCommand = false;
     state.maneuveringModeCommand = false;
     state.hullDamaged = false;
-    // Clear automation orders (prevents stale orders after NPC→PC conversion)
+    // Clear automation orders and task (prevents stale state after NPC→PC conversion)
     state.order = Order.NONE;
     state.orderTargetId = null;
     state.orderPosition.x = 0;
     state.orderPosition.y = 0;
+    state.currentTask = '';
 }
 
 function resetThruster(thruster: Thruster) {

--- a/modules/core/test/automation-order.spec.ts
+++ b/modules/core/test/automation-order.spec.ts
@@ -144,13 +144,14 @@ describe('automation order on NPC ships', () => {
 });
 
 describe('resetShipState clears orders', () => {
-    it('clears order fields', () => {
+    it('clears order fields and currentTask', () => {
         const state = makeShipState('test', dragonflyConfig);
 
         state.order = Order.ATTACK;
         state.orderTargetId = 'target-1';
         state.orderPosition.x = 100;
         state.orderPosition.y = 200;
+        state.currentTask = 'Attack target-1';
 
         resetShipState(state);
 
@@ -159,5 +160,33 @@ describe('resetShipState clears orders', () => {
         expect(state.orderTargetId).to.be.null;
         expect(state.orderPosition.x).to.equal(0);
         expect(state.orderPosition.y).to.equal(0);
+        expect(state.currentTask).to.equal('');
+    });
+});
+
+describe('NPC to PC conversion clears stale currentTask', () => {
+    it('PC ship constructed from NPC state has empty currentTask', () => {
+        // Simulate NPC state: order and currentTask set during NPC execution
+        const spaceMgr = new SpaceManager();
+        const shipObj = new Spaceship();
+        shipObj.id = '1';
+        const die = new MockDie();
+        die.expectedRoll = 1;
+        spaceMgr.insert(shipObj);
+
+        // Build an NPC state with stale task info (as would exist during NPC→PC conversion)
+        const npcState = makeShipState(shipObj.id, dragonflyConfig);
+        npcState.order = Order.MOVE;
+        npcState.orderPosition.x = 5000;
+        npcState.orderPosition.y = 2000;
+        npcState.currentTask = 'Go to 5000,2000';
+
+        // Simulate convertShipType: clone state, then create PC manager
+        const clonedState = npcState.clone();
+        // After clone, stale currentTask should survive until resetShipState is called
+        // Creating ShipManagerPc calls resetShipState in its constructor
+        const pcMgr = new ShipManagerPc(shipObj, clonedState, spaceMgr, die);
+
+        expect(pcMgr.state.currentTask).to.equal('');
     });
 });


### PR DESCRIPTION
Closes #1847

## What was left

PR #1876 fixed the main bug (GM orders being applied to player ships) but left one loose end: `resetShipState` cleared `order`, `orderTargetId`, and `orderPosition` but **not** `currentTask`.

After NPC→PC conversion, the stale task description (e.g. `"Go to 5000,2000"` or `"Attack target-1"`) persisted indefinitely on the PC ship. This caused:
- UI showed an ongoing automation task even though the ship was fully pilot-controlled
- `cancelTask()` guard (`if (this.shipManager.state.currentTask)`) would silently run cleanup if ever triggered on the converted PC ship

## Fix

Added `state.currentTask = ''` to `resetShipState` in `ship-manager-abstract.ts`.

## Tests added

Two new tests in `automation-order.spec.ts`:
- `resetShipState clears order fields and currentTask` — directly tests the reset function
- `PC ship constructed from NPC state has empty currentTask` — end-to-end NPC→PC clone scenario

## Verification

```
npm run test:types   ✅ no errors
npm run test:format  ✅ no errors
npm run build        ✅ all modules
npm test             ✅ 233 passed, 2 skipped, 0 failed (30 suites)
```

🤖 Automated by Claude Code
https://claude.ai/code/session_01SfzZ6rtdJWhKmNM6o38e9M

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfzZ6rtdJWhKmNM6o38e9M)_