### PR TITLE
fix: systems start at Normal power instead of Max (closes #1895)

### DIFF
--- a/docs/json-ptr.md
+++ b/docs/json-ptr.md
@@ -69,7 +69,7 @@ class Reactor extends SystemState {
     @tweakable({ type: 'enum', enum: PowerLevel })
     @commandable()
     @gameField('float32')
-    public power = PowerLevel.MAX;
+    public power = PowerLevel.NORMAL;
 }
 ```
 

--- a/docs/specs/SHIP_SYSTEMS_SPEC.md
+++ b/docs/specs/SHIP_SYSTEMS_SPEC.md
@@ -50,7 +50,7 @@ abstract class SystemState extends Schema {
     
     @range([0, 1])
     @gameField('float32')
-    power: number = PowerLevel.MAX;
+    power: number = PowerLevel.NORMAL;
     
     @range([0, 1])
     @gameField('float32')

--- a/modules/core/src/ship/system.ts
+++ b/modules/core/src/ship/system.ts
@@ -96,7 +96,7 @@ export abstract class SystemState extends Schema {
     @tweakable({ type: 'enum', enum: PowerLevel })
     @commandable()
     @gameField('float32')
-    public power = PowerLevel.MAX;
+    public power = PowerLevel.NORMAL;
 
     @range([0, 1])
     @tweakable({ type: 'enum', enum: HackLevel })

--- a/modules/core/test/ship-manager.spec.ts
+++ b/modules/core/test/ship-manager.spec.ts
@@ -141,8 +141,8 @@ describe.each([ShipManagerPc, ShipManagerNpc])('%p', (shipManagerCtor) => {
                     spaceMgr.insert(shipObj);
                     shipMgr.setSmartPilotManeuveringMode(SmartPilotMode.DIRECT);
                     shipMgr.setSmartPilotRotationMode(SmartPilotMode.DIRECT);
-                    shipMgr.state.chainGun!.rateOfFireFactor = 1;
                     shipMgr.state.chainGun!.power = PowerLevel.MAX;
+                    shipMgr.state.chainGun!.rateOfFireFactor = 1;
                     shipMgr.state.chainGun!.design.use_BlastCannonShell = false;
                     shipMgr.state.chainGun!.design.use_Missile = false;
                     shipMgr.state.chainGun!.design.use_CannonShell = true;

--- a/modules/core/test/ship-manager.spec.ts
+++ b/modules/core/test/ship-manager.spec.ts
@@ -2,6 +2,7 @@ import {
     Asteroid,
     EPSILON,
     Explosion,
+    PowerLevel,
     ShipManagerNpc,
     ShipManagerPc,
     SmartPilotMode,
@@ -101,6 +102,7 @@ describe.each([ShipManagerPc, ShipManagerNpc])('%p', (shipManagerCtor) => {
                 spaceMgr.insert(shipObj);
                 shipMgr.setSmartPilotManeuveringMode(SmartPilotMode.DIRECT);
                 shipMgr.setSmartPilotRotationMode(SmartPilotMode.DIRECT);
+                shipMgr.state.chainGun!.power = PowerLevel.MAX;
                 shipMgr.state.chainGun!.isFiring = true;
                 switchToAvailableAmmo(shipMgr.state.chainGun!, shipMgr.state.magazine);
 
@@ -140,6 +142,7 @@ describe.each([ShipManagerPc, ShipManagerNpc])('%p', (shipManagerCtor) => {
                     shipMgr.setSmartPilotManeuveringMode(SmartPilotMode.DIRECT);
                     shipMgr.setSmartPilotRotationMode(SmartPilotMode.DIRECT);
                     shipMgr.state.chainGun!.rateOfFireFactor = 1;
+                    shipMgr.state.chainGun!.power = PowerLevel.MAX;
                     shipMgr.state.chainGun!.design.use_BlastCannonShell = false;
                     shipMgr.state.chainGun!.design.use_Missile = false;
                     shipMgr.state.chainGun!.design.use_CannonShell = true;
@@ -215,6 +218,7 @@ describe.each([ShipManagerPc, ShipManagerNpc])('%p', (shipManagerCtor) => {
                     spaceMgr.insert(shipObj);
                     shipMgr.setSmartPilotManeuveringMode(SmartPilotMode.DIRECT);
                     shipMgr.setSmartPilotRotationMode(SmartPilotMode.DIRECT);
+                    shipMgr.state.chainGun!.power = PowerLevel.MAX;
                     shipMgr.state.chainGun!.rateOfFireFactor = 0.5;
                     shipMgr.state.chainGun!.design.bulletsPerSecond = bulletsPerSecond;
                     shipMgr.state.chainGun!.isFiring = true;

--- a/modules/core/test/ship-test-harness.ts
+++ b/modules/core/test/ship-test-harness.ts
@@ -2,6 +2,7 @@ import { GraphPointInput, PlotlyGraphBuilder } from './ploty-graph-builder';
 import {
     Iterator,
     MAX_SAFE_FLOAT,
+    PowerLevel,
     ShipManagerPc,
     SmartPilotMode,
     SpaceManager,
@@ -194,6 +195,7 @@ export class ShipTestHarness {
         this.shipObj.id = '1';
         this.spaceMgr.insert(this.shipObj);
         global.harness = this;
+        this.shipMgr.state.maneuvering.power = PowerLevel.MAX;
         this.shipMgr.setSmartPilotManeuveringMode(SmartPilotMode.DIRECT);
         this.shipMgr.setSmartPilotRotationMode(SmartPilotMode.DIRECT);
     }

--- a/modules/core/test/ship-test-harness.ts
+++ b/modules/core/test/ship-test-harness.ts
@@ -195,9 +195,13 @@ export class ShipTestHarness {
         this.shipObj.id = '1';
         this.spaceMgr.insert(this.shipObj);
         global.harness = this;
-        this.shipMgr.state.maneuvering.power = PowerLevel.MAX;
         this.shipMgr.setSmartPilotManeuveringMode(SmartPilotMode.DIRECT);
         this.shipMgr.setSmartPilotRotationMode(SmartPilotMode.DIRECT);
+        // Physics tests assume full-power systems; set explicitly since default is NORMAL
+        this.shipMgr.state.maneuvering.power = PowerLevel.MAX;
+        for (const thruster of this.shipMgr.state.thrusters) {
+            thruster.power = PowerLevel.MAX;
+        }
     }
 
     get shipState() {

--- a/modules/core/test/signals-job-manager.spec.ts
+++ b/modules/core/test/signals-job-manager.spec.ts
@@ -49,6 +49,8 @@ function createTestSetup() {
     );
     ships.set(targetObj.id, targetMgr);
 
+    // Set signals to MAX power so job timing matches test expectations
+    shipMgr.state.signals.power = PowerLevel.MAX;
     // Flush entities so ships are in state before first update
     spaceMgr.forceFlushEntities();
     // Warmup tick to establish radar range and FOV

--- a/modules/core/test/signals-job-manager.spec.ts
+++ b/modules/core/test/signals-job-manager.spec.ts
@@ -1,6 +1,7 @@
 import {
     Faction,
     HackLevel,
+    PowerLevel,
     ScanLevel,
     ShipManagerPc,
     SmartPilotMode,
@@ -30,6 +31,7 @@ function createTestSetup() {
     spaceMgr.insert(shipObj);
     shipMgr.setSmartPilotManeuveringMode(SmartPilotMode.DIRECT);
     shipMgr.setSmartPilotRotationMode(SmartPilotMode.DIRECT);
+    shipMgr.state.signals.power = PowerLevel.MAX;
 
     // Create a target ship within radar range
     const targetObj = new Spaceship();

--- a/modules/core/test/system.spec.ts
+++ b/modules/core/test/system.spec.ts
@@ -1,4 +1,4 @@
-import { DesignState, SystemState, defectible, getSystems } from '../src/ship/system';
+import { DesignState, PowerLevel, SystemState, defectible, getSystems } from '../src/ship/system';
 
 import { ArraySchema } from '@colyseus/schema';
 import { expect } from 'chai';
@@ -38,6 +38,13 @@ class Target extends SystemState {
         return 3;
     }
 }
+
+describe('SystemState', () => {
+    it('defaults power to NORMAL, not MAX', () => {
+        const target = new Target();
+        expect(target.power).to.equal(PowerLevel.NORMAL);
+    });
+});
 
 describe('defectible', () => {
     it('getSystems() gets all defectible properties', () => {


### PR DESCRIPTION
Closes #1895

## Summary

- Change `SystemState.power` default from `PowerLevel.MAX` to `PowerLevel.NORMAL` so Engineer station has meaningful power management decisions from session start
- Update tests that test specific mechanics (chaingun rate, signals job speed, maneuvering) to explicitly set `power = PowerLevel.MAX` — their purpose is to test the mechanic, not the default power level
- Update `docs/json-ptr.md` and `docs/specs/SHIP_SYSTEMS_SPEC.md` code examples to reflect the new default

## MUST fill in (do not delete this section)

State sync invariants:

- [x] I did NOT write directly to `*.state.position`, `*.state.velocity`,
      `*.state.angle`, `*.state.turnSpeed`, or `*.state.health` outside
      `syncShipProperties` (`modules/core/src/ship/ship-manager-abstract.ts`)
      or `space-manager.ts`. If I did, I have justified it below.

`@gameField` decorator order:

- [x] Any new `@gameField` is the INNERMOST decorator (declared LAST, below
      `@tweakable`, `@range`, etc.). Decorator order is enforced by lint;
      see `docs/PATTERNS.md`. (No new `@gameField` decorators added.)

Remote command surface:

- [x] Any property a client must remotely write satisfies one of four
      admission clauses: `@commandable()` (leaf), `@commandable({ '/x': true })`
      on a parent property (nested Schema descendant), `@tweakable` (GM tweak
      panel), or `DesignState` subclass (GM design-state panel). Bare
      `@gameField`s outside those clauses are **always rejected** (no
      warn-only mode). See `docs/json-ptr.md`. (No new remote-writable properties added.)

Public API:

- [x] I did NOT add new exports to `modules/core/src/index.public.ts`
      without explicit reviewer approval. Internal symbols belong in
      `index.internal.ts` and are imported via `@starwards/core/internal`.

Local verification:

- [x] I ran `npm run test:static && npm test` locally and they pass.
- [x] If I touched a station screen, I ran the relevant E2E spec under
      `modules/e2e/test/` locally. (No station screens touched.)

Skill / docs hygiene:

- [x] If I changed behavior documented in `.claude/skills/` or `docs/`,
      I updated the relevant skill / doc in the same PR. (Updated `docs/json-ptr.md` and `docs/specs/SHIP_SYSTEMS_SPEC.md`.)
- [x] No new top-level singletons, unbounded caches, or globally mutable
      module state were introduced.

## Hotspot files touched

none

## Tests added or updated

- `modules/core/test/system.spec.ts` — new test: `SystemState defaults power to NORMAL, not MAX`
- `modules/core/test/ship-manager.spec.ts` — chaingun tests set explicit `power = MAX`
- `modules/core/test/signals-job-manager.spec.ts` — signals test setup sets `power = MAX`
- `modules/core/test/ship-test-harness.ts` — `ShipTestHarness` sets `maneuvering.power = MAX`

## Skills reviewed

- `starwards-autonomous`
- `starwards-tdd`
- `starwards-verification`

🤖 Automated by Claude Code
https://claude.ai/code/session_01MZQM3zj1ZYpgDDXQkG9ios