### PR TITLE
feat: add callsign and transponderOpen fields to Spaceship (closes #1924)

### DIFF
--- a/modules/core/src/space/spaceship.ts
+++ b/modules/core/src/space/spaceship.ts
@@ -25,6 +25,14 @@ export class Spaceship extends SpaceObjectBase {
     @gameField('string')
     public model: ShipModel | null = null;
 
+    @tweakable('string')
+    @gameField('string')
+    public callsign = '';
+
+    @tweakable('boolean')
+    @gameField('boolean')
+    public transponderOpen = true;
+
     constructor() {
         super();
         this.radius = Spaceship.radius;
@@ -35,6 +43,9 @@ export class Spaceship extends SpaceObjectBase {
         this.position = position;
         this.model = shipModel;
         this.faction = faction;
+        if (!this.callsign) {
+            this.callsign = id;
+        }
         return this;
     }
 }

--- a/modules/core/test/spaceship.spec.ts
+++ b/modules/core/test/spaceship.spec.ts
@@ -1,0 +1,29 @@
+import { Faction, Spaceship, Vec2 } from '../src';
+
+describe('Spaceship', () => {
+    describe('callsign field', () => {
+        test('defaults to empty string', () => {
+            const ship = new Spaceship();
+            expect(ship.callsign).toBe('');
+        });
+
+        test('init() sets callsign to id when callsign is empty', () => {
+            const ship = new Spaceship().init('my-ship-id', new Vec2(0, 0), 'dragonfly-SF22', Faction.NONE);
+            expect(ship.callsign).toBe('my-ship-id');
+        });
+
+        test('init() does not overwrite a pre-set callsign', () => {
+            const ship = new Spaceship();
+            ship.callsign = 'Alpha';
+            ship.init('my-ship-id', new Vec2(0, 0), 'dragonfly-SF22', Faction.NONE);
+            expect(ship.callsign).toBe('Alpha');
+        });
+    });
+
+    describe('transponderOpen field', () => {
+        test('defaults to true', () => {
+            const ship = new Spaceship();
+            expect(ship.transponderOpen).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
Closes #1924

## Summary

- Adds `callsign: string` to `Spaceship` — defaults to `''`, GM-tweakable, synced via `@gameField('string')`
- Adds `transponderOpen: boolean` to `Spaceship` — defaults to `true`, GM-tweakable, synced via `@gameField('boolean')`
- `init()` derives a placeholder callsign from ship `id` when `callsign` is empty at spawn

## MUST fill in (do not delete this section)

State sync invariants:

- [x] I did NOT write directly to `*.state.position`, `*.state.velocity`,
      `*.state.angle`, `*.state.turnSpeed`, or `*.state.health` outside
      `syncShipProperties` (`modules/core/src/ship/ship-manager-abstract.ts`)
      or `space-manager.ts`. If I did, I have justified it below.

`@gameField` decorator order:

- [x] Any new `@gameField` is the INNERMOST decorator (declared LAST, below
      `@tweakable`, `@range`, etc.). Decorator order is enforced by lint;
      see `docs/PATTERNS.md`. (`@tweakable` above `@gameField` for both new fields.)

Remote command surface:

- [x] Any property a client must remotely write satisfies one of four
      admission clauses: `@commandable()` (leaf), `@commandable({ '/x': true })`
      on a parent property (nested Schema descendant), `@tweakable` (GM tweak
      panel), or `DesignState` subclass (GM design-state panel). Bare
      `@gameField`s outside those clauses are **always rejected** (no
      warn-only mode). See `docs/json-ptr.md`. (Both fields are `@tweakable` — GM tweak panel.)

Public API:

- [x] I did NOT add new exports to `modules/core/src/index.public.ts`
      without explicit reviewer approval. Internal symbols belong in
      `index.internal.ts` and are imported via `@starwards/core/internal`. (No new exports added.)

Local verification:

- [x] I ran `npm run test:static && npm test` locally and they pass.
- [x] If I touched a station screen, I ran the relevant E2E spec under
      `modules/e2e/test/` locally. (No station screen touched.)

Skill / docs hygiene:

- [x] If I changed behavior documented in `.claude/skills/` or `docs/`,
      I updated the relevant skill / doc in the same PR. (No existing skill/doc covers these new fields.)
- [x] No new top-level singletons, unbounded caches, or globally mutable
      module state were introduced.

## Hotspot files touched

none

## Tests added or updated

- `modules/core/test/spaceship.spec.ts` — new file: 4 unit tests covering `callsign` default, `transponderOpen` default, and callsign derivation from id in `init()`

## Skills reviewed

`starwards-tdd`, `starwards-verification`, `starwards-autonomous`

🤖 Automated by Claude Code
https://claude.ai/code/session_01GhXk75A9HEfKGQgLjjx2f5