### PR TITLE
fix: preserve GM radar view when new ship is added (closes #1914)

### DIFF
--- a/modules/browser/src/screens/gm.ts
+++ b/modules/browser/src/screens/gm.ts
@@ -137,7 +137,6 @@ void driver.waitForGame().then(
             dashboard.registerWidget(dockingWidget(spaceDriver, shipDriver), {}, shipId + ' docking');
             dashboard.registerWidget(targetInfoWidget(spaceDriver, shipDriver), {}, shipId + ' target info');
             dashboard.registerWidget(longRangeRadarWidget(spaceDriver, shipDriver), {}, shipId + ' long range radar');
-            dashboard.setup();
         }
     },
     (e) => logError(e),

--- a/modules/browser/src/widgets/dashboard.ts
+++ b/modules/browser/src/widgets/dashboard.ts
@@ -89,13 +89,17 @@ export class Dashboard extends GoldenLayout {
     ) {
         name = name || wName;
         this.registerComponent(name, component);
-        this.widgets.push({
+        const widget = {
             name,
             type,
             component,
             defaultProps: { ...defaultProps, ...props },
             makeHeaders,
-        } as DashboardWidget);
+        } as DashboardWidget;
+        this.widgets.push(widget);
+        if (this.isInitialised) {
+            this.registerWidgetMenuItem(widget.name, getGoldenLayoutItemConfig(widget));
+        }
     }
 
     private registerWidgetMenuItem(name: string, newItemConfig: GoldenLayout.ItemConfigType) {

--- a/modules/e2e/test/gm-screen.spec.ts
+++ b/modules/e2e/test/gm-screen.spec.ts
@@ -38,4 +38,51 @@ test.describe('GM Screen', () => {
         const menuContainer = page.locator('#menuContainer');
         await expect(menuContainer).toBeVisible({ timeout: 10000 });
     });
+
+    test('does not reset radar view when a new ship is created via GM UI', async ({ page }) => {
+        const radarCanvas = page.locator('[data-id="GM Radar"]');
+        await expect(radarCanvas).toBeVisible({ timeout: 15000 });
+
+        // Wait for all initial ship widgets to be registered (GVTS long range radar is last)
+        const menuContainer = page.locator('#menuContainer');
+        await expect(menuContainer.locator('[data-id="menu-GVTS long range radar"]')).toBeVisible({
+            timeout: 15000,
+        });
+
+        // Count menu items after initial setup
+        const initialMenuCount = await menuContainer.locator('li[data-id]').count();
+
+        // Scroll on the radar to zoom out (deltaY=500 → zoom changes from 1.0 to ~0.5)
+        await radarCanvas.hover();
+        await page.mouse.wheel(0, 500);
+
+        // Wait for data-zoom attribute to update
+        await page.waitForTimeout(300);
+
+        // Verify zoom changed from default 1.0
+        const zoomAfterScroll = parseFloat((await radarCanvas.getAttribute('data-zoom')) ?? '1');
+        expect(zoomAfterScroll).toBeLessThan(1.0);
+
+        // Switch to the "create" tab in the GM panel
+        const createTab = page.locator('.lm_title', { hasText: 'create' });
+        await createTab.click();
+
+        // Click the "Create Ship" action button (tp-btnv_b) to enter ship placement mode
+        const createShipButton = page.locator('button.tp-btnv_b', { hasText: 'Create Ship' });
+        await expect(createShipButton).toBeVisible({ timeout: 5000 });
+        await createShipButton.click();
+
+        // Click on the radar canvas to place the new ship
+        await radarCanvas.click({ position: { x: 100, y: 100 } });
+
+        // Wait for the new ship's widgets to appear in the menu (count increases by at least 1)
+        await expect(async () => {
+            const count = await menuContainer.locator('li[data-id]').count();
+            expect(count).toBeGreaterThan(initialMenuCount);
+        }).toPass({ timeout: 15000 });
+
+        // The radar zoom must NOT have reset to 1.0
+        const zoomAfterShipAdded = parseFloat((await radarCanvas.getAttribute('data-zoom')) ?? '1');
+        expect(zoomAfterShipAdded).toBeCloseTo(zoomAfterScroll, 2);
+    });
 });


### PR DESCRIPTION
## Summary

- `Dashboard.registerWidget` now adds the drag-menu item directly when the layout is already initialised, so callers don't need to call `setup()` again after the initial load.
- Removed the redundant `dashboard.setup()` call from `gm.ts`'s ship-registration loop; that call was rebuilding the entire GoldenLayout on every ship detection, resetting the radar camera position and zoom to defaults.
- Added E2E regression test: scroll radar to change zoom, create a new ship via GM UI, assert zoom is preserved.

## MUST fill in (do not delete this section)

State sync invariants:

- [x] I did NOT write directly to `*.state.position`, `*.state.velocity`,
      `*.state.angle`, `*.state.turnSpeed`, or `*.state.health` outside
      `syncShipProperties` (`modules/core/src/ship/ship-manager-abstract.ts`)
      or `space-manager.ts`. If I did, I have justified it below.

`@gameField` decorator order:

- [x] Any new `@gameField` is the INNERMOST decorator (declared LAST, below
      `@tweakable`, `@range`, etc.). Decorator order is enforced by lint;
      see `docs/PATTERNS.md`.

Remote command surface:

- [x] Any property a client must remotely write satisfies one of four
      admission clauses: `@commandable()` (leaf), `@commandable({ '/x': true })`
      on a parent property (nested Schema descendant), `@tweakable` (GM tweak
      panel), or `DesignState` subclass (GM design-state panel). Bare
      `@gameField`s outside those clauses are **always rejected** (no
      warn-only mode). See `docs/json-ptr.md`.

Public API:

- [x] I did NOT add new exports to `modules/core/src/index.public.ts`
      without explicit reviewer approval. Internal symbols belong in
      `index.internal.ts` and are imported via `@starwards/core/internal`.

Local verification:

- [x] I ran `npm run test:static && npm test` locally and they pass.
- [x] If I touched a station screen, I ran the relevant E2E spec under
      `modules/e2e/test/` locally.

Skill / docs hygiene:

- [x] If I changed behavior documented in `.claude/skills/` or `docs/`,
      I updated the relevant skill / doc in the same PR.
- [x] No new top-level singletons, unbounded caches, or globally mutable
      module state were introduced.

## Hotspot files touched

none

## Tests added or updated

`modules/e2e/test/gm-screen.spec.ts` — new regression test `does not reset radar view when a new ship is created via GM UI`

## Skills reviewed

`starwards-autonomous`, `starwards-tdd`, `starwards-verification`

---
Closes #1914

🤖 Automated by Claude Code
https://claude.ai/code/session_01QJ5AAvaGWopYpmAdmQLGcy