### PR TITLE
fix: wire weapons-fire heat for chain-gun and tubes (closes #1923)

### DIFF
--- a/modules/core/src/configurations/dragonfly-sf-22.ts
+++ b/modules/core/src/configurations/dragonfly-sf-22.ts
@@ -34,6 +34,8 @@ export const dragonflyChaingun = {
     use_BlastCannonShell: true,
     damage50: 20,
     energyCost: 1,
+    heat_CannonShell: 5,
+    heat_BlastCannonShell: 5,
 };
 export const dragonflyReactor = {
     modelName: 'Helios-1000 Fusion Reactor',
@@ -79,6 +81,7 @@ export const dragonflyTube = {
     overrideSecondsToLive: 10,
     energyCost: 30,
     use_Missile: true,
+    heat_Missile: 25,
 };
 export const dragonflyTargeting = {
     modelName: 'Falcon Targeting Computer',

--- a/modules/core/src/ship/chain-gun-manager.ts
+++ b/modules/core/src/ship/chain-gun-manager.ts
@@ -1,3 +1,4 @@
+import { EnergySource, HeatSink } from './ship-manager-abstract';
 import { Faction, Projectile, ScanLevel, SpaceObject, Spaceship, projectileModels } from '../space';
 import { IterationData, Updateable } from '../updateable';
 import { SpaceManager, XY, calcShellSecondsToLive, capToRange, lerp } from '../logic';
@@ -6,7 +7,6 @@ import { Vec2, gaussianRandom } from '..';
 import { ChainGun } from './chain-gun';
 import { DeepReadonly } from 'ts-essentials';
 import { EPSILON } from '../logic';
-import { EnergySource } from './ship-manager-abstract';
 import { Iterator } from '../logic/iteration';
 import { Magazine } from './magazine';
 import { ShipState } from './ship-state';
@@ -46,6 +46,7 @@ export class ChainGunManager implements Updateable {
         private spaceManager: SpaceManager,
         private shipManager: ShipManager,
         private energyManager: EnergySource,
+        private heatSink: HeatSink,
     ) {
         switchToAvailableAmmo(chainGun, state.magazine);
     }
@@ -171,7 +172,8 @@ export class ChainGunManager implements Updateable {
             chainGun.loading >= 1 &&
             chainGun.loadedProjectile !== 'None'
         ) {
-            const projectile = new Projectile(chainGun.loadedProjectile);
+            const firedProjectileType = chainGun.loadedProjectile;
+            const projectile = new Projectile(firedProjectileType);
             chainGun.loading = 0;
             chainGun.loadedProjectile = 'None';
             projectile.angle = gaussianRandom(
@@ -205,6 +207,8 @@ export class ChainGunManager implements Updateable {
                 projectile.secondsToLive = chainGun.shellSecondsToLive;
             }
             this.spaceManager.insert(projectile);
+            const heatPerShot = chainGun.design[`heat_${firedProjectileType}`] ?? 0;
+            this.heatSink.addHeat(heatPerShot * chainGun.effectiveness, chainGun);
         }
     }
 }

--- a/modules/core/src/ship/chain-gun.ts
+++ b/modules/core/src/ship/chain-gun.ts
@@ -23,6 +23,9 @@ export type ChaingunDesign = {
     use_CannonShell?: boolean;
     use_BlastCannonShell?: boolean;
     use_Missile?: boolean;
+    heat_CannonShell?: number;
+    heat_BlastCannonShell?: number;
+    heat_Missile?: number;
 };
 
 export class ChaingunDesignState extends DesignState implements ChaingunDesign {
@@ -37,6 +40,9 @@ export class ChaingunDesignState extends DesignState implements ChaingunDesign {
     @gameField('boolean') use_CannonShell = false;
     @gameField('boolean') use_BlastCannonShell = false;
     @gameField('boolean') use_Missile = false;
+    @gameField('float32') heat_CannonShell = 0;
+    @gameField('float32') heat_BlastCannonShell = 0;
+    @gameField('float32') heat_Missile = 0;
 
     // get explosionSecondsToLive(): number {
     //     return this.explosionRadius / this.explosionExpansionSpeed;

--- a/modules/core/src/ship/ship-manager-abstract.ts
+++ b/modules/core/src/ship/ship-manager-abstract.ts
@@ -24,6 +24,7 @@ import { AutomationManager } from './automation-manager';
 import { DamageManager } from './damage-manager';
 import { DeepReadonly } from 'ts-essentials';
 import { DockingManager } from './docking-manager';
+import { HeatManager } from './heat-manager';
 import { Iterator } from '../logic/iteration';
 import { Magazine } from './magazine';
 import { Maneuvering } from './maneuvering';
@@ -106,9 +107,13 @@ export type Die = {
 export interface EnergySource {
     trySpendEnergy(value: number, system?: ShipSystem): boolean;
 }
+export interface HeatSink {
+    addHeat(value: number, system: ShipSystem): void;
+}
 export abstract class ShipManager implements Updateable {
     protected readonly internalProxy = {
         trySpendEnergy: (_: number, _2?: ShipSystem) => false,
+        addHeat: (_: number, _2: ShipSystem) => undefined as void,
     };
     public weaponsTarget: SpaceObject | null = null;
 
@@ -117,6 +122,7 @@ export abstract class ShipManager implements Updateable {
     protected dockingManager: DockingManager;
     protected automationManager: AutomationManager;
     protected damageManager: DamageManager;
+    protected heatManager: HeatManager;
     public signalsJobManager: SignalsJobManager;
 
     constructor(
@@ -129,6 +135,8 @@ export abstract class ShipManager implements Updateable {
         resetShipState(this.state);
 
         this.damageManager = new DamageManager(this.spaceObject, this.state, this.spaceManager, this.die);
+        this.heatManager = new HeatManager(this.state, this.damageManager);
+        this.internalProxy.addHeat = this.heatManager.addHeat.bind(this.heatManager);
         this.dockingManager = new DockingManager(this.state, this.spaceManager, this.damageManager);
         this.automationManager = new AutomationManager(this.state, this, this.spaceManager);
         this.signalsJobManager = new SignalsJobManager(this.state, this.spaceManager, this.die, this.ships);
@@ -140,11 +148,20 @@ export abstract class ShipManager implements Updateable {
                 this.spaceManager,
                 this,
                 this.internalProxy,
+                this.internalProxy,
             );
         }
         for (const tube of this.state.tubes) {
             this.tubeManagers.push(
-                new ChainGunManager(tube, this.spaceObject, this.state, this.spaceManager, this, this.internalProxy),
+                new ChainGunManager(
+                    tube,
+                    this.spaceObject,
+                    this.state,
+                    this.spaceManager,
+                    this,
+                    this.internalProxy,
+                    this.internalProxy,
+                ),
             );
         }
     }
@@ -219,6 +236,7 @@ export abstract class ShipManager implements Updateable {
         this.syncShipProperties();
         this.healPlates(id.deltaSeconds);
         this.damageManager.update();
+        this.heatManager.update(id);
         this.automationManager.update(id);
 
         this.validateWeaponsTargetId();

--- a/modules/core/src/ship/ship-manager.ts
+++ b/modules/core/src/ship/ship-manager.ts
@@ -12,14 +12,12 @@ import {
 
 import { DeepReadonly } from 'ts-essentials';
 import { EnergyManager } from './energy-manager';
-import { HeatManager } from './heat-manager';
 import { IterationData } from '../updateable';
 import { MovementManager } from './movement-manager';
 import { SpaceManager } from '../logic/space-manager';
 
 export class ShipManagerPc extends ShipManager implements PcShipApi {
     readonly isPlayerShip = true;
-    private heatManager: HeatManager;
     private energyManager: EnergyManager;
     private smartPilotManeuveringMode: StatesToggle<SmartPilotMode>;
     private smartPilotRotationMode: StatesToggle<SmartPilotMode>;
@@ -45,7 +43,6 @@ export class ShipManagerPc extends ShipManager implements PcShipApi {
             SmartPilotMode.VELOCITY,
             SmartPilotMode.TARGET,
         );
-        this.heatManager = new HeatManager(this.state, this.damageManager);
         this.energyManager = new EnergyManager(this.state, this.heatManager);
         this.movementManager = new MovementManager(
             this.spaceObject,
@@ -76,7 +73,6 @@ export class ShipManagerPc extends ShipManager implements PcShipApi {
     update(id: IterationData) {
         super.update(id);
 
-        this.heatManager.update(id);
         this.movementManager.update(id);
         this.handleToggleSmartPilotRotationMode();
         this.handleToggleSmartPilotManeuveringMode();

--- a/modules/core/test/ship-manager.spec.ts
+++ b/modules/core/test/ship-manager.spec.ts
@@ -200,6 +200,75 @@ describe.each([ShipManagerPc, ShipManagerNpc])('%p', (shipManagerCtor) => {
         );
     });
 
+    it('chaingun must add heat when firing', () => {
+        fc.assert(
+            fc.property(fc.integer({ min: 15, max: 20 }), (numIterationsPerSecond: number) => {
+                const spaceMgr = new SpaceManager();
+                const shipObj = new Spaceship();
+                shipObj.id = '1';
+                const shipMgr = new shipManagerCtor(
+                    shipObj,
+                    makeShipState(shipObj.id, dragonflyConfig),
+                    spaceMgr,
+                    new MockDie(),
+                );
+                spaceMgr.insert(shipObj);
+                shipMgr.setSmartPilotManeuveringMode(SmartPilotMode.DIRECT);
+                shipMgr.setSmartPilotRotationMode(SmartPilotMode.DIRECT);
+                shipMgr.state.chainGun!.power = PowerLevel.MAX;
+                shipMgr.state.chainGun!.isFiring = true;
+                // disable cooling and reactor heat to isolate weapon heat
+                shipMgr.state.design.totalCoolant = 0;
+                shipMgr.state.reactor.design.energyHeatEPMThreshold = Infinity;
+                switchToAvailableAmmo(shipMgr.state.chainGun!, shipMgr.state.magazine);
+                const heatPerShell = shipMgr.state.chainGun!.design.heat_CannonShell;
+
+                const i = makeIterationsData(1, numIterationsPerSecond);
+                for (const id of i) {
+                    shipMgr.update(id);
+                    spaceMgr.update(id);
+                }
+                const shotsFired = [...spaceMgr.state.getAll('Projectile')].length;
+                expect(shotsFired).to.be.greaterThan(0);
+                expect(shipMgr.state.chainGun!.heat).to.be.closeTo(shotsFired * heatPerShell, heatPerShell);
+            }),
+        );
+    });
+
+    it('tube must add heat when firing', () => {
+        const spaceMgr = new SpaceManager();
+        const shipObj = new Spaceship();
+        shipObj.id = '1';
+        const shipMgr = new shipManagerCtor(
+            shipObj,
+            makeShipState(shipObj.id, dragonflyConfig),
+            spaceMgr,
+            new MockDie(),
+        );
+        spaceMgr.insert(shipObj);
+        shipMgr.setSmartPilotManeuveringMode(SmartPilotMode.DIRECT);
+        shipMgr.setSmartPilotRotationMode(SmartPilotMode.DIRECT);
+        // disable cooling and reactor heat to isolate weapon heat
+        shipMgr.state.design.totalCoolant = 0;
+        shipMgr.state.reactor.design.energyHeatEPMThreshold = Infinity;
+        // fire first tube only for 2 seconds so at least 1 missile fires (rate: 1/s)
+        const tube = shipMgr.state.tubes[0];
+        tube.power = PowerLevel.MAX;
+        tube.isFiring = true;
+        switchToAvailableAmmo(tube, shipMgr.state.magazine);
+        const heatPerMissile = tube.design.heat_Missile;
+
+        const numIterationsPerSecond = 20;
+        const i = makeIterationsData(2, numIterationsPerSecond * 2);
+        for (const id of i) {
+            shipMgr.update(id);
+            spaceMgr.update(id);
+        }
+        const projectiles = [...spaceMgr.state.getAll('Projectile')];
+        expect(projectiles.length).to.be.greaterThan(0);
+        expect(tube.heat).to.be.closeTo(projectiles.length * heatPerMissile, heatPerMissile);
+    });
+
     it('chaingun with cooling failure must have reduced rate of fire', () => {
         fc.assert(
             fc.property(


### PR DESCRIPTION
Closes #1923

## Summary

- Wire `HeatManager.addHeat()` into `ChainGunManager.fireChainGun()` so each shot adds heat to the firing subsystem (chain-gun and tubes)
- Add `heat_CannonShell`, `heat_BlastCannonShell`, `heat_Missile` design fields to `ChaingunDesign`; placeholder values 5/shot for shells, 25/shot for missiles
- Move `HeatManager` from `ShipManagerPc` to the abstract `ShipManager` base so NPC ships also accumulate weapons heat

## MUST fill in (do not delete this section)

State sync invariants:

- [x] I did NOT write directly to `*.state.position`, `*.state.velocity`,
      `*.state.angle`, `*.state.turnSpeed`, or `*.state.health` outside
      `syncShipProperties` (`modules/core/src/ship/ship-manager-abstract.ts`)
      or `space-manager.ts`. If I did, I have justified it below.

`@gameField` decorator order:

- [x] Any new `@gameField` is the INNERMOST decorator (declared LAST, below
      `@tweakable`, `@range`, etc.). Decorator order is enforced by lint;
      see `docs/PATTERNS.md`. (New `heat_*` fields have `@gameField` as their only decorator.)

Remote command surface:

- [x] Any property a client must remotely write satisfies one of four
      admission clauses: `@commandable()` (leaf), `@commandable({ '/x': true })`
      on a parent property (nested Schema descendant), `@tweakable` (GM tweak
      panel), or `DesignState` subclass (GM design-state panel). Bare
      `@gameField`s outside those clauses are **always rejected** (no
      warn-only mode). See `docs/json-ptr.md`. (New fields are on `ChaingunDesignState extends DesignState` — covered by the DesignState admission clause.)

Public API:

- [x] I did NOT add new exports to `modules/core/src/index.public.ts`
      without explicit reviewer approval. Internal symbols belong in
      `index.internal.ts` and are imported via `@starwards/core/internal`.

Local verification:

- [x] I ran `npm run test:static && npm test` locally and they pass.
- [x] If I touched a station screen, I ran the relevant E2E spec under
      `modules/e2e/test/` locally. (No station screen touched; all 30 E2E tests pass.)

Skill / docs hygiene:

- [x] If I changed behavior documented in `.claude/skills/` or `docs/`,
      I updated the relevant skill / doc in the same PR. (No skill/doc changes needed — heat infra was already documented as existing but unwired.)
- [x] No new top-level singletons, unbounded caches, or globally mutable
      module state were introduced.

## Hotspot files touched

- `modules/core/src/ship/ship-manager-abstract.ts` — moved `HeatManager` here from `ShipManagerPc`, added `HeatSink` interface, wired `internalProxy.addHeat`

## Tests added or updated

`modules/core/test/ship-manager.spec.ts`:
- `chaingun must add heat when firing` — verifies `chainGun.heat` ≈ `shots × heat_CannonShell` after 1 second of firing (run for both `ShipManagerPc` and `ShipManagerNpc`)
- `tube must add heat when firing` — verifies tube heat ≈ `missiles × heat_Missile` after 2 seconds (ensures at least 1 shot fires at 1 RPS)

## Skills reviewed

- `starwards-autonomous`, `starwards-tdd`, `starwards-verification`

🤖 Automated by Claude Code
https://claude.ai/code/session_01WV7qSZVTdNeA7AXLUXtLf7