### PR TITLE
fix: wire weapons-fire heat to chain-gun and tubes (closes #1923)

### DIFF
--- a/modules/core/src/configurations/dragonfly-sf-22.ts
+++ b/modules/core/src/configurations/dragonfly-sf-22.ts
@@ -34,6 +34,8 @@ export const dragonflyChaingun = {
     use_BlastCannonShell: true,
     damage50: 20,
     energyCost: 1,
+    heat_CannonShell: 5,
+    heat_BlastCannonShell: 5,
 };
 export const dragonflyReactor = {
     modelName: 'Helios-1000 Fusion Reactor',
@@ -79,6 +81,7 @@ export const dragonflyTube = {
     overrideSecondsToLive: 10,
     energyCost: 30,
     use_Missile: true,
+    heat_Missile: 25,
 };
 export const dragonflyTargeting = {
     modelName: 'Falcon Targeting Computer',

--- a/modules/core/src/ship/chain-gun-manager.ts
+++ b/modules/core/src/ship/chain-gun-manager.ts
@@ -1,3 +1,4 @@
+import { EnergySource, HeatSource } from './ship-manager-abstract';
 import { Faction, Projectile, ScanLevel, SpaceObject, Spaceship, projectileModels } from '../space';
 import { IterationData, Updateable } from '../updateable';
 import { SpaceManager, XY, calcShellSecondsToLive, capToRange, lerp } from '../logic';
@@ -6,7 +7,6 @@ import { Vec2, gaussianRandom } from '..';
 import { ChainGun } from './chain-gun';
 import { DeepReadonly } from 'ts-essentials';
 import { EPSILON } from '../logic';
-import { EnergySource } from './ship-manager-abstract';
 import { Iterator } from '../logic/iteration';
 import { Magazine } from './magazine';
 import { ShipState } from './ship-state';
@@ -46,6 +46,7 @@ export class ChainGunManager implements Updateable {
         private spaceManager: SpaceManager,
         private shipManager: ShipManager,
         private energyManager: EnergySource,
+        private heatSource: HeatSource,
     ) {
         switchToAvailableAmmo(chainGun, state.magazine);
     }
@@ -171,7 +172,8 @@ export class ChainGunManager implements Updateable {
             chainGun.loading >= 1 &&
             chainGun.loadedProjectile !== 'None'
         ) {
-            const projectile = new Projectile(chainGun.loadedProjectile);
+            const firedProjectileType = chainGun.loadedProjectile;
+            const projectile = new Projectile(firedProjectileType);
             chainGun.loading = 0;
             chainGun.loadedProjectile = 'None';
             projectile.angle = gaussianRandom(
@@ -205,6 +207,12 @@ export class ChainGunManager implements Updateable {
                 projectile.secondsToLive = chainGun.shellSecondsToLive;
             }
             this.spaceManager.insert(projectile);
+            const heatPerShot = chainGun.design[`heat_${firedProjectileType}` as keyof typeof chainGun.design] as
+                | number
+                | undefined;
+            if (heatPerShot) {
+                this.heatSource.addHeat(heatPerShot * chainGun.effectiveness, chainGun);
+            }
         }
     }
 }

--- a/modules/core/src/ship/chain-gun.ts
+++ b/modules/core/src/ship/chain-gun.ts
@@ -23,6 +23,9 @@ export type ChaingunDesign = {
     use_CannonShell?: boolean;
     use_BlastCannonShell?: boolean;
     use_Missile?: boolean;
+    heat_CannonShell?: number;
+    heat_BlastCannonShell?: number;
+    heat_Missile?: number;
 };
 
 export class ChaingunDesignState extends DesignState implements ChaingunDesign {
@@ -37,6 +40,9 @@ export class ChaingunDesignState extends DesignState implements ChaingunDesign {
     @gameField('boolean') use_CannonShell = false;
     @gameField('boolean') use_BlastCannonShell = false;
     @gameField('boolean') use_Missile = false;
+    @gameField('float32') heat_CannonShell = 0;
+    @gameField('float32') heat_BlastCannonShell = 0;
+    @gameField('float32') heat_Missile = 0;
 
     // get explosionSecondsToLive(): number {
     //     return this.explosionRadius / this.explosionExpansionSpeed;

--- a/modules/core/src/ship/ship-manager-abstract.ts
+++ b/modules/core/src/ship/ship-manager-abstract.ts
@@ -106,9 +106,17 @@ export type Die = {
 export interface EnergySource {
     trySpendEnergy(value: number, system?: ShipSystem): boolean;
 }
+
+export interface HeatSource {
+    addHeat(value: number, system: ShipSystem): void;
+}
+
 export abstract class ShipManager implements Updateable {
     protected readonly internalProxy = {
         trySpendEnergy: (_: number, _2?: ShipSystem) => false,
+        addHeat: (_: number, _2: ShipSystem) => {
+            // no-op until HeatManager is wired up in ShipManagerPc
+        },
     };
     public weaponsTarget: SpaceObject | null = null;
 
@@ -140,11 +148,20 @@ export abstract class ShipManager implements Updateable {
                 this.spaceManager,
                 this,
                 this.internalProxy,
+                this.internalProxy,
             );
         }
         for (const tube of this.state.tubes) {
             this.tubeManagers.push(
-                new ChainGunManager(tube, this.spaceObject, this.state, this.spaceManager, this, this.internalProxy),
+                new ChainGunManager(
+                    tube,
+                    this.spaceObject,
+                    this.state,
+                    this.spaceManager,
+                    this,
+                    this.internalProxy,
+                    this.internalProxy,
+                ),
             );
         }
     }

--- a/modules/core/src/ship/ship-manager.ts
+++ b/modules/core/src/ship/ship-manager.ts
@@ -57,6 +57,7 @@ export class ShipManagerPc extends ShipManager implements PcShipApi {
             this.die,
         );
         this.internalProxy.trySpendEnergy = this.energyManager.trySpendEnergy;
+        this.internalProxy.addHeat = this.heatManager.addHeat.bind(this.heatManager);
     }
 
     public handleToggleSmartPilotManeuveringMode() {

--- a/modules/core/test/chain-gun-manager.spec.ts
+++ b/modules/core/test/chain-gun-manager.spec.ts
@@ -68,6 +68,44 @@ describe('ChainGunManager', () => {
         });
     });
 
+    describe('heat on fire', () => {
+        it('adds per-shot heat scaled by effectiveness when firing CannonShell', () => {
+            const spaceMgr = new SpaceManager();
+            const shipObj = new Spaceship();
+            shipObj.id = '1';
+            const die = new MockDie();
+            const shipMgr = new ShipManagerPc(shipObj, makeShipState(shipObj.id, dragonflyConfig), spaceMgr, die);
+            die.expectedRoll = 1;
+            spaceMgr.insert(shipObj);
+            shipMgr.setSmartPilotManeuveringMode(SmartPilotMode.DIRECT);
+            shipMgr.setSmartPilotRotationMode(SmartPilotMode.DIRECT);
+
+            const chainGun = shipMgr.state.chainGun!;
+            // Set a large heat-per-shot to dominate over energy-heat
+            chainGun.design.heat_CannonShell = 20;
+            // Disable coolant so heat doesn't drain
+            shipMgr.state.design.totalCoolant = 0;
+            // Disable energy-heat by setting threshold above practical usage
+            shipMgr.state.reactor.design.energyHeatEPMThreshold = 1e6;
+
+            chainGun.isFiring = true;
+            chainGun.loadAmmo = true;
+            switchToAvailableAmmo(chainGun, shipMgr.state.magazine);
+
+            const i = makeIterationsData(1, 20);
+            for (const id of i) {
+                shipMgr.update(id);
+                spaceMgr.update(id);
+            }
+
+            const shotsCount = [...spaceMgr.state.getAll('Projectile')].length;
+            // Should have fired multiple shots
+            expect(shotsCount).to.be.greaterThan(0);
+            // Heat should be at least shots * heat_CannonShell (per-shot heat * shots fired)
+            expect(chainGun.heat).to.be.greaterThanOrEqual(shotsCount * 20 * chainGun.effectiveness * 0.9);
+        });
+    });
+
     describe('loading and firing', () => {
         it('decrements magazine ammo on fire', () => {
             const spaceMgr = new SpaceManager();


### PR DESCRIPTION
Closes #1923

## Summary

- Added `heat_CannonShell`, `heat_BlastCannonShell`, `heat_Missile` design fields to `ChaingunDesign` / `ChaingunDesignState` — configurable heat per shot, following the `use_*` template pattern
- `ChainGunManager.fireChainGun()` now calls `HeatManager.addHeat(heat * effectiveness, chainGun)` after each shot, via a new `HeatSource` interface injected through `internalProxy` (same pattern as `EnergySource`)
- Placeholder values set for dragonfly-SF22: 5 heat/shot for shells, 25 heat/shot for missiles

## MUST fill in (do not delete this section)

State sync invariants:

- [x] I did NOT write directly to `*.state.position`, `*.state.velocity`,
      `*.state.angle`, `*.state.turnSpeed`, or `*.state.health` outside
      `syncShipProperties` (`modules/core/src/ship/ship-manager-abstract.ts`)
      or `space-manager.ts`. If I did, I have justified it below.

`@gameField` decorator order:

- [x] Any new `@gameField` is the INNERMOST decorator (declared LAST, below
      `@tweakable`, `@range`, etc.). Decorator order is enforced by lint;
      see `docs/PATTERNS.md`.

Remote command surface:

- [x] Any property a client must remotely write satisfies one of four
      admission clauses: `@commandable()` (leaf), `@commandable({ '/x': true })`
      on a parent property (nested Schema descendant), `@tweakable` (GM tweak
      panel), or `DesignState` subclass (GM design-state panel). Bare
      `@gameField`s outside those clauses are **always rejected** (no
      warn-only mode). See `docs/json-ptr.md`.
      New `heat_*` fields are on `ChaingunDesignState` (a `DesignState` subclass) — GM-tweakable by design.

Public API:

- [x] I did NOT add new exports to `modules/core/src/index.public.ts`
      without explicit reviewer approval. Internal symbols belong in
      `index.internal.ts` and are imported via `@starwards/core/internal`.

Local verification:

- [x] I ran `npm run test:static && npm test` locally and they pass.
- [x] If I touched a station screen, I ran the relevant E2E spec under
      `modules/e2e/test/` locally. (No station screens touched.)

Skill / docs hygiene:

- [x] If I changed behavior documented in `.claude/skills/` or `docs/`,
      I updated the relevant skill / doc in the same PR. (No skill/doc changes needed.)
- [x] No new top-level singletons, unbounded caches, or globally mutable
      module state were introduced.

## Hotspot files touched

- `modules/core/src/ship/ship-manager-abstract.ts` — added `HeatSource` interface and `addHeat` no-op to `internalProxy`

## Tests added or updated

- `modules/core/test/chain-gun-manager.spec.ts` — added `heat on fire` test verifying per-shot heat scaled by effectiveness

## Skills reviewed

- `starwards-tdd`, `starwards-verification`, `starwards-autonomous`

🤖 Automated by Claude Code