### PR TITLE
feat: tier-1 passive scan promotion after 5-second dwell in range (closes #1925)

### DIFF
--- a/modules/core/src/ship/signals-job-manager.ts
+++ b/modules/core/src/ship/signals-job-manager.ts
@@ -6,8 +6,11 @@ import { Die } from './ship-manager-abstract';
 import { ScanLevel } from '../space/scan-level';
 import { ShipState } from './ship-state';
 import { SpaceManager } from '../logic/space-manager';
+import { Spaceship } from '../space/spaceship';
 import { XY } from '../logic';
 import { makeId } from '../id';
+
+const TIER1_DWELL_SECONDS = 5;
 
 type IncomingHack = {
     systemName: string;
@@ -37,6 +40,8 @@ export class SignalsJobManager implements Updateable {
     // Not persisted: lost on server restart (hacked systems stay COMPROMISED until manually reset)
     private incomingHacks: IncomingHack[] = [];
     private hackCooldowns: HackCooldown[] = [];
+    // Ephemeral per-target dwell timers for tier-1 passive scan promotion
+    private tier1DwellTimers = new Map<string, number>();
 
     constructor(
         private state: ShipState,
@@ -60,6 +65,7 @@ export class SignalsJobManager implements Updateable {
         this.trimExcessJobs();
         this.processJobQueue(deltaSeconds, totalSeconds);
         this.validateTrackedTargets();
+        this.updateTier1ScanPromotion(deltaSeconds);
     }
 
     private processSubmitJobCommand(totalSeconds: number): void {
@@ -294,6 +300,32 @@ export class SignalsJobManager implements Updateable {
             if (!this.isTargetInRange(targetId)) {
                 this.state.signals.trackedTargets.splice(i, 1);
                 this.spaceManager.setTrack(this.state.id, this.state.faction, targetId, false);
+            }
+        }
+    }
+
+    private updateTier1ScanPromotion(deltaSeconds: number): void {
+        const seenIds = new Set<string>();
+        for (const target of this.spaceManager.state.getAll('Spaceship')) {
+            if (target.id === this.state.id) continue;
+            const inRange = this.isTargetInRange(target.id);
+            const scanLevel = this.spaceManager.getScanLevel(target.id, this.state.faction);
+            const transponderOpen = Spaceship.isInstance(target) && target.transponderOpen;
+            if (inRange && transponderOpen && scanLevel === ScanLevel.UFO) {
+                seenIds.add(target.id);
+                const dwell = (this.tier1DwellTimers.get(target.id) ?? 0) + deltaSeconds;
+                if (dwell >= TIER1_DWELL_SECONDS) {
+                    this.spaceManager.setScanLevel(target.id, this.state.faction, ScanLevel.BASIC);
+                    this.tier1DwellTimers.delete(target.id);
+                } else {
+                    this.tier1DwellTimers.set(target.id, dwell);
+                }
+            }
+        }
+        // TODO B7: reset timer on leaving range (re-entry rule undecided)
+        for (const id of this.tier1DwellTimers.keys()) {
+            if (!seenIds.has(id)) {
+                this.tier1DwellTimers.delete(id);
             }
         }
     }

--- a/modules/core/test/signals-job-manager.spec.ts
+++ b/modules/core/test/signals-job-manager.spec.ts
@@ -315,8 +315,10 @@ describe('SignalsJobManager', () => {
 
     describe('scan job effects', () => {
         it('should upgrade scan level UFO -> BASIC on success', () => {
-            const { shipMgr, spaceMgr, die } = createTestSetup();
+            const { shipMgr, spaceMgr, die, targetObj } = createTestSetup();
             die.expectedRoll = 0;
+            // close transponder so passive tier-1 promotion does not promote during the job
+            targetObj.transponderOpen = false;
 
             queueJob(shipMgr, JobType.SCAN, 'target1');
             tick(shipMgr, spaceMgr, 0.05, 0.05);
@@ -341,8 +343,10 @@ describe('SignalsJobManager', () => {
         });
 
         it('should not change scan level on failure', () => {
-            const { shipMgr, spaceMgr, die } = createTestSetup();
+            const { shipMgr, spaceMgr, die, targetObj } = createTestSetup();
             die.expectedRoll = 0.99;
+            // close transponder so passive tier-1 promotion does not interfere with this test
+            targetObj.transponderOpen = false;
 
             queueJob(shipMgr, JobType.SCAN, 'target1');
             tick(shipMgr, spaceMgr, 0.05, 0.05);
@@ -622,6 +626,54 @@ describe('SignalsJobManager', () => {
             tick(shipMgr, spaceMgr, 0.05, 0.1);
 
             expect(shipMgr.state.signals.jobs.length).to.be.at.most(1);
+        });
+    });
+
+    describe('tier-1 passive scan promotion', () => {
+        it('promotes UFO contact to BASIC after 5 continuous seconds in range with open transponder', () => {
+            const { shipMgr, spaceMgr } = createTestSetup();
+            // targetObj.transponderOpen defaults to true; target1 is at (1000, 0), within radarRange 10,000
+            expect(spaceMgr.getScanLevel('target1', Faction.Gravitas)).to.equal(ScanLevel.UFO);
+
+            // 4.9 seconds in range – not yet promoted
+            runTicks(shipMgr, spaceMgr, 4.9, 20, 0.05);
+            expect(spaceMgr.getScanLevel('target1', Faction.Gravitas)).to.equal(ScanLevel.UFO);
+
+            // 0.2 more seconds – crosses 5-second threshold
+            runTicks(shipMgr, spaceMgr, 0.2, 20, 4.95);
+            expect(spaceMgr.getScanLevel('target1', Faction.Gravitas)).to.equal(ScanLevel.BASIC);
+        });
+
+        it('does not promote if transponder is closed', () => {
+            const { shipMgr, spaceMgr, targetObj } = createTestSetup();
+            targetObj.transponderOpen = false;
+
+            // 6 seconds in range – transponder closed, promotion blocked
+            runTicks(shipMgr, spaceMgr, 6, 20, 0.05);
+            expect(spaceMgr.getScanLevel('target1', Faction.Gravitas)).to.equal(ScanLevel.UFO);
+        });
+
+        it('resets dwell timer when contact leaves range', () => {
+            const { shipMgr, spaceMgr, targetObj } = createTestSetup();
+
+            // 3 seconds in range – timer at 3, not yet promoted
+            runTicks(shipMgr, spaceMgr, 3, 20, 0.05);
+            expect(spaceMgr.getScanLevel('target1', Faction.Gravitas)).to.equal(ScanLevel.UFO);
+
+            // move out of range – timer resets
+            targetObj.position.x = 20000;
+            tick(shipMgr, spaceMgr, 0.1, 3.15);
+
+            // move back in range
+            targetObj.position.x = 1000;
+
+            // 4.9 seconds since re-entry – timer reset, not yet promoted
+            runTicks(shipMgr, spaceMgr, 4.9, 20, 3.25);
+            expect(spaceMgr.getScanLevel('target1', Faction.Gravitas)).to.equal(ScanLevel.UFO);
+
+            // 0.2 more seconds – completes 5 seconds of continuous in-range dwell
+            runTicks(shipMgr, spaceMgr, 0.2, 20, 8.15);
+            expect(spaceMgr.getScanLevel('target1', Faction.Gravitas)).to.equal(ScanLevel.BASIC);
         });
     });
 });


### PR DESCRIPTION
Closes #1925

## Summary

- Adds ephemeral dwell timers to `SignalsJobManager` (one per in-range target) that accumulate per tick
- After 5 continuous seconds inside the scanner's radar range **and** the target's `transponderOpen === true`, the contact is auto-promoted from `ScanLevel.UFO` to `ScanLevel.BASIC` via `spaceManager.setScanLevel`
- Timer resets when the target leaves range (`// TODO B7`: re-entry rule undecided per issue spec)
- Closed transponder blocks promotion entirely, regardless of dwell time
- Same-faction shortcut in `getScanLevel` is left untouched

## MUST fill in (do not delete this section)

State sync invariants:

- [x] I did NOT write directly to `*.state.position`, `*.state.velocity`,
      `*.state.angle`, `*.state.turnSpeed`, or `*.state.health` outside
      `syncShipProperties` or `space-manager.ts`.

`@gameField` decorator order:

- [x] No new `@gameField` decorators added.

Remote command surface:

- [x] No new commandable properties added.

Public API:

- [x] I did NOT add new exports to `modules/core/src/index.public.ts`.

Local verification:

- [x] I ran `npm run test:types && npm run test:format && npm run build && npm test` locally and all pass (266 tests, 0 failures).
- [x] No station screen touched; E2E tests not required.

Skill / docs hygiene:

- [x] No skill/doc changes needed — the passive scan logic is a new code path with no existing documentation to update.
- [x] No new top-level singletons, unbounded caches, or globally mutable module state were introduced (dwell timers live on a per-`SignalsJobManager` instance).

## Hotspot files touched

- `modules/core/src/ship/signals-job-manager.ts` — added `tier1DwellTimers`, `updateTier1ScanPromotion`, and import for `Spaceship`

## Tests added or updated

`modules/core/test/signals-job-manager.spec.ts`:
- `tier-1 passive scan promotion > promotes UFO contact to BASIC after 5 continuous seconds in range with open transponder` — verifies promotion fires after ≥5 s but not before
- `tier-1 passive scan promotion > does not promote if transponder is closed` — verifies gate condition
- `tier-1 passive scan promotion > resets dwell timer when contact leaves range` — verifies // TODO B7 re-entry behaviour
- Two existing tests (`should upgrade scan level UFO -> BASIC on success`, `should not change scan level on failure`) updated to close target transponder so they remain isolated from passive promotion

## Skills reviewed

`starwards-autonomous`, `starwards-tdd`, `starwards-verification`

🤖 Automated by Claude Code
https://claude.ai/code/session_01BnVHwH1fSH4JqDp9anod67

---
_Generated by [Claude Code](https://claude.ai/code/session_01BnVHwH1fSH4JqDp9anod67)_