### PR TITLE
fix(build): deterministic @starwards/server resolution + complete local tsc builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 <p align="center">
   <a href="https://discord.gg/p56nSVEjdb"><img alt="Discord Chat" src="https://img.shields.io/discord/843041591772971028?color=5865F2&label=discord&style=flat-square"></a>
-  <a href="https://circleci.com/gh/starwards/starwards/tree/master"><img alt="CircleCI" src="https://circleci.com/gh/starwards/starwards/tree/master.svg?style=svg"></a>
+  <a href="https://github.com/starwards/starwards/actions/workflows/ci-cd.yml?query=branch%3Amaster"><img alt="CI" src="https://github.com/starwards/starwards/actions/workflows/ci-cd.yml/badge.svg?branch=master"></a>
 
 <video src='https://user-images.githubusercontent.com/6019373/178277941-01a61ddb-c6cb-4620-b5aa-966291710d69.mp4' width=180/>
 </p>
@@ -26,11 +26,20 @@ Starwards is a space and starship simulator designed specifically for LARPs (Liv
 
 # how to run and use it
 
-Currently executables are being built after every change. 
-click on [this link](https://app.circleci.com/pipelines/github/starwards/starwards?branch=master&filter=build&status=none&status=success), click on the top-most "build" workflow, then on the "build executables" job, then on the "artifacts" tab, and choose the executable that fits your computer. 
-download and run it, and open [this link](http://localhost/) in your browser.
+Executables are built by CI on every change to master.
+Open the [CI workflow runs](https://github.com/starwards/starwards/actions/workflows/ci-cd.yml?query=branch%3Amaster), click the top-most run, scroll to the "Artifacts" section, and download the "Windows executable" (requires being signed in to GitHub).
+Run it, and open [this link](http://localhost/) in your browser.
 
 This is not a solution we like. We are [open to improvements and suggestions](https://github.com/starwards/starwards/issues/832).
+
+# developing
+
+```sh
+npm ci          # install dependencies
+npm run dev     # core watch + game server + web dev server, one terminal
+```
+
+Then open [http://localhost:3000](http://localhost:3000). See [Contributing to Starwards](CONTRIBUTING.md) for the full setup, [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for build/test workflows, and the [docs index](docs/) for architecture and design references.
 
 ### the game is running! now what?
 Missing documentation. contributions are welcomed!

--- a/modules/node-red/tsconfig.runtime.json
+++ b/modules/node-red/tsconfig.runtime.json
@@ -4,6 +4,10 @@
     "compilerOptions": {
         "module": "commonjs",
         "outDir": "dist",
+        // keep incremental state inside the cleaned output dir — a
+        // tsbuildinfo that survives `rimraf ./dist` makes tsc skip
+        // re-emitting unchanged files into the now-empty dir
+        "tsBuildInfoFile": "./dist/.tsbuildinfo",
         "rootDir": "src",
         "experimentalDecorators": true,
         "paths": {

--- a/modules/server/package.json
+++ b/modules/server/package.json
@@ -3,6 +3,7 @@
     "version": "0.0.0",
     "private": true,
     "license": "SEE LICENSE IN LICENSE.md",
+    "main": "cjs/index.js",
     "files": [
         "cjs"
     ],

--- a/modules/server/tsconfig.runtime.json
+++ b/modules/server/tsconfig.runtime.json
@@ -3,6 +3,10 @@
     "compilerOptions": {
         "module": "commonjs",
         "outDir": "cjs",
+        // keep incremental state inside the cleaned output dir — a
+        // tsbuildinfo that survives `rimraf ./cjs` makes tsc skip
+        // re-emitting unchanged files into the now-empty dir
+        "tsBuildInfoFile": "./cjs/.tsbuildinfo",
         "rootDir": "src",
         "experimentalDecorators": true,
         "paths": {


### PR DESCRIPTION
## Summary

- Root-cause fix for the 5 perpetually-flaky e2e specs (`Cannot find module '@starwards/server'`, present on master — see the "Known CI flakiness" note in docs/testing/README.md): `@starwards/server` had no `main`, so resolution depended on Playwright's tsconfig-paths hook winning a worker-startup race against `require-in-the-middle` (injected by `@colyseus/core → @pm2/io`). Added `main: cjs/index.js`, mirroring `@starwards/core`.
- Fixes silently-incomplete local builds: `tsconfig.runtime.tsbuildinfo` survived the prebuild `rimraf` of the output dir, so local `build:server`/node-red builds re-emitted only recently-changed files (a clean local server build produced 4 of 31 files, no `index.js`). `tsBuildInfoFile` is now pinned inside the cleaned output dir. CI was unaffected (fresh checkouts).
- README refresh: dead CircleCI badge/instructions replaced with GitHub Actions equivalents, plus a `npm run dev` quick-start section.

## MUST fill in (do not delete this section)

State sync invariants:

- [x] I did NOT write directly to `*.state.position`, `*.state.velocity`,
      `*.state.angle`, `*.state.turnSpeed`, or `*.state.health` outside
      `syncShipProperties` (`modules/core/src/ship/ship-manager-abstract.ts`)
      or `space-manager.ts`. If I did, I have justified it below.

`@gameField` decorator order:

- [x] Any new `@gameField` is the INNERMOST decorator (declared LAST, below
      `@tweakable`, `@range`, etc.). Decorator order is enforced by lint;
      see `docs/PATTERNS.md`. (No code changes at all — config + docs only.)

Remote command surface:

- [x] Any property a client must remotely write satisfies one of four
      admission clauses: `@commandable()` (leaf), `@commandable({ '/x': true })`
      on a parent property (nested Schema descendant), `@tweakable` (GM tweak
      panel), or `DesignState` subclass (GM design-state panel). Bare
      `@gameField`s outside those clauses are **always rejected** (no
      warn-only mode). See `docs/json-ptr.md`. (No new remote-writable properties.)

Public API:

- [x] I did NOT add new exports to `modules/core/src/index.public.ts`
      without explicit reviewer approval. Internal symbols belong in
      `index.internal.ts` and are imported via `@starwards/core/internal`.

Local verification:

- [x] I ran `npm run test:format && npm run test:types && npm test` locally and they pass.
- [x] If I touched a station screen, I ran the relevant E2E spec under
      `modules/e2e/test/` locally. (No station screens touched.)

Skill / docs hygiene:

- [x] If I changed behavior documented in `.claude/skills/` or `docs/`,
      I updated the relevant skill / doc in the same PR.
- [x] No new top-level singletons, unbounded caches, or globally mutable
      module state were introduced.

## Hotspot files touched

none

## Tests added or updated

none — config-only change; existing suites cover it (server jest suite passes; the proof for the flake fix is the Test-E2e run summary on this PR: expect 0 flaky vs the recurring 5 on master).

## Skills reviewed

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)