### PR TITLE
fix(core): prevent weapons targeting of waypoints

### DIFF
--- a/modules/core/src/ship/ship-manager-abstract.ts
+++ b/modules/core/src/ship/ship-manager-abstract.ts
@@ -197,7 +197,7 @@ export abstract class ShipManager implements Updateable {
         const iterable: Iterable<SpaceObject> = this.state.weaponsTarget.shipOnly
             ? this.spaceManager.state.getAll('Spaceship')
             : this.spaceManager.state;
-        let result = new Iterator(iterable).filter((v) => v.id !== this.state.id);
+        let result = new Iterator(iterable).filter((v) => v.id !== this.state.id && v.isCorporal);
         if (this.state.weaponsTarget.enemyOnly) {
             result = result.filter((v) => v.faction !== Faction.NONE && v.faction !== this.state.faction);
         }
@@ -301,6 +301,9 @@ export abstract class ShipManager implements Updateable {
     protected validateWeaponsTargetId() {
         if (typeof this.state.weaponsTarget.targetId === 'string') {
             this.weaponsTarget = this.spaceManager.state.get(this.state.weaponsTarget.targetId) || null;
+            if (this.weaponsTarget && !this.weaponsTarget.isCorporal) {
+                this.weaponsTarget = null;
+            }
             if (!this.weaponsTarget) {
                 this.state.weaponsTarget.targetId = null;
             } else {

--- a/modules/core/test/ship-manager-targeting.spec.ts
+++ b/modules/core/test/ship-manager-targeting.spec.ts
@@ -2,6 +2,7 @@ import {
     Asteroid,
     Faction,
     ShipManagerPc,
+    Waypoint,
     SmartPilotMode,
     SpaceManager,
     Spaceship,
@@ -108,6 +109,32 @@ describe('ShipManager weapons target lifecycle', () => {
         mgr.handleTargetCommands();
         expect(mgr.state.weaponsTarget.targetId).to.equal('c');
         expect(mgr.state.weaponsTarget.nextTargetCommand).to.equal(false);
+    });
+
+    it('nextTargetCommand never selects a waypoint', () => {
+        const { spaceMgr, makeShipMgr, flush } = setup();
+        const { mgr } = makeShipMgr('a', Faction.Gravitas);
+        const waypoint = new Waypoint().init('wp', Vec2.make({ x: 500, y: 0 }));
+        waypoint.faction = Faction.Gravitas;
+        spaceMgr.insert(waypoint);
+        flush();
+        mgr.state.weaponsTarget.shipOnly = false;
+        mgr.state.weaponsTarget.enemyOnly = false;
+        mgr.state.weaponsTarget.nextTargetCommand = true;
+        mgr.handleTargetCommands();
+        expect(mgr.state.weaponsTarget.targetId).to.equal(null);
+    });
+
+    it('setTarget rejects a waypoint id', () => {
+        const { spaceMgr, makeShipMgr, flush } = setup();
+        const { mgr } = makeShipMgr('a', Faction.Gravitas);
+        const waypoint = new Waypoint().init('wp', Vec2.make({ x: 500, y: 0 }));
+        waypoint.faction = Faction.Gravitas;
+        spaceMgr.insert(waypoint);
+        flush();
+        mgr.setTarget('wp');
+        expect(mgr.state.weaponsTarget.targetId).to.equal(null);
+        expect(mgr.weaponsTarget).to.equal(null);
     });
 
     it('nextTargetCommand with enemyOnly skips same-faction ships', () => {

--- a/modules/core/test/ship-manager-targeting.spec.ts
+++ b/modules/core/test/ship-manager-targeting.spec.ts
@@ -2,12 +2,12 @@ import {
     Asteroid,
     Faction,
     ShipManagerPc,
-    Waypoint,
     SmartPilotMode,
     SpaceManager,
     Spaceship,
     TargetedStatus,
     Vec2,
+    Waypoint,
     makeShipState,
     shipConfigurations,
 } from '../src';


### PR DESCRIPTION
## Summary
- Weapons officer could cycle to / lock onto waypoints from the weapons screen.
- Root cause: `getViableTargetIds()` never filtered non-corporal objects, and `validateWeaponsTargetId()` accepted any object id. Waypoints carry a faction, so they passed the visibility check.
- Fix: filter `isCorporal` in target cycling, and reject non-corporal targets in `validateWeaponsTargetId()` (covers direct `setTarget` from radar click as well).

## Testing
- Added two tests in `ship-manager-targeting.spec.ts`: next-target cycling skips waypoints; `setTarget` rejects a waypoint id. The cycling test failed before the fix.
- Full core suite passes (301 tests) and `npm run test:types` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)