### PR TITLE
ci: allow claude bot to trigger code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'claude'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Summary
The **Claude Code Review** workflow fails on PRs opened by the `claude` bot (e.g. #1940) with:

> Action failed with error: Workflow initiated by non-human actor: claude (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.

This adds `allowed_bots: 'claude'` to the `anthropics/claude-code-action@v1` step so reviews run on bot-authored PRs. The action normalizes names (strips `[bot]`, lowercases), so `claude` matches the actor.

Also bumps `actions/checkout` v4 → v5 to clear the Node 20 deprecation annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)