### PR TITLE
ci: surface preview deploy via GitHub environment instead of PR comment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,6 +62,9 @@ jobs:
     needs: build-push
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
+    environment:
+      name: ${{ needs.build-push.outputs.release }}
+      url: https://${{ needs.build-push.outputs.host }}
     steps:
       - uses: actions/checkout@v4
 
@@ -86,31 +89,12 @@ jobs:
           envsubst < .github/k8s/template.yaml | kubectl apply -f -
           kubectl -n starwards rollout status deployment/starwards-${RELEASE} --timeout=180s
 
-      - name: Comment preview URL
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const pr = context.payload.pull_request.number;
-            const url = `https://pr-${pr}.${{ env.BASE_DOMAIN }}`;
-            const body = `🎮 Preview deployed: ${url}`;
-            const { data: comments } = await github.rest.issues.listComments({
-              ...context.repo, issue_number: pr
-            });
-            const existing = comments.find(c => c.body.includes('Preview deployed:'));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                ...context.repo, comment_id: existing.id, body
-              });
-            } else {
-              await github.rest.issues.createComment({
-                ...context.repo, issue_number: pr, body
-              });
-            }
-
   teardown:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
     steps:
       - uses: tailscale/github-action@v3
         with:
@@ -129,3 +113,29 @@ jobs:
           kubectl -n starwards delete deployment,svc,ingressroute \
             -l app=starwards,release=pr-${{ github.event.pull_request.number }} \
             --ignore-not-found
+
+      - name: Remove GitHub deployment environment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const environment = `pr-${context.payload.pull_request.number}`;
+            const { data: deployments } = await github.rest.repos.listDeployments({
+              ...context.repo, environment, per_page: 100
+            });
+            for (const d of deployments) {
+              await github.rest.repos.createDeploymentStatus({
+                ...context.repo, deployment_id: d.id, state: 'inactive'
+              });
+              await github.rest.repos.deleteDeployment({
+                ...context.repo, deployment_id: d.id
+              });
+            }
+            // Deleting the environment shell needs admin rights, which
+            // GITHUB_TOKEN may not have — best-effort only.
+            try {
+              await github.rest.repos.deleteAnEnvironment({
+                ...context.repo, environment_name: environment
+              });
+            } catch (e) {
+              core.warning(`Could not delete environment ${environment}: ${e.message}`);
+            }


### PR DESCRIPTION
## What
- The `deploy` job now declares a GitHub `environment` (`pr-N` / `master`) with the preview URL, so PRs get the native **"This branch was successfully deployed — View deployment"** box above the merge box instead of a comment that gets lost in the thread.
- Removed the sticky preview-URL comment step (now redundant).
- `teardown` deactivates and deletes the PR's deployment records on close. Deleting the environment *shell* requires admin rights that `GITHUB_TOKEN` may lack, so it's best-effort with a warning; leftover shells in Settings → Environments are harmless but can be cleaned manually or with a PAT later.

## Why
The preview link in PR comments gets buried. Environments/Deployments is GitHub's designated surface for exactly this, and the URL stays deterministic (`https://pr-<N>.dev.starwards.space`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)