### PR TITLE
docs: Open Stage Control knowledge base (osc-controllers skill + verified reference)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,6 +17,8 @@
             "Bash(git status*)",
             "Bash(git diff*)",
             "Bash(git log*)",
+            "Bash(git fetch:*)",
+            "Bash(git pull:*)",
             "Bash(gh auth status)",
             "Bash(gh issue list*)",
             "Bash(gh issue view*)"

--- a/.claude/skills/osc-controllers/SKILL.md
+++ b/.claude/skills/osc-controllers/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: osc-controllers
+description: Use when working on the OSC controller framework - Open Stage Control layouts/custom modules, Node-RED OSC bridge flows, tablet touch controllers, or Playwright E2E tests that drive Open Stage Control widgets. Also use when debugging OSC message routing, widget feedback loops, or O-S-C deployment in Docker.
+version: 2026-07-04
+related_skills:
+  - starwards-tdd (E2E-first workflow)
+  - starwards-verification (evidence before claiming done)
+---
+
+# OSC Controllers (Open Stage Control ⇄ Node-RED ⇄ Starwards)
+
+Touch/MIDI control surfaces via Open Stage Control (O-S-C), bridged to the game by Node-RED. Convention: **widget OSC address = admitted JSON Pointer** (e.g. fader address `/reactor/power`). All facts verified against O-S-C **v1.30.3** primary sources (Framagit source + official docs); provenance in `docs/reference/open-stage-control-reference.md`.
+
+## Critical facts (agents get these wrong from memory)
+
+1. **O-S-C is NOT on npm.** `npm install open-stage-control` fails — no such package. Deploy from the Framagit release asset `open-stage-control-[version]-node.zip` (pure Node, no Electron/xvfb) and run `node /path/to/open-stage-control --no-gui ...`. There is no `--headless` flag; the flag is `--no-gui`.
+2. **The user-defined widget `id` is NOT in the DOM.** Widget containers are `<div class="widget {type}-container" id="{hash}" data-widget="{hash}">` where `{hash}` is an internal uuid. Resolve widgets in tests via `el._widget_instance` (see [reference/playwright-testing.md](reference/playwright-testing.md)).
+3. **A custom module cannot read the widget tree directly.** Enumerate widgets by listening to `app.on('sessionSetPath')`/`app.on('sessionOpened')` (payload has the session file path) and walking the file with `loadJSON(path)`.
+4. **Per-client sessions are NOT selected by URL.** No `?session=`/`?load=` query param exists. One instance serves per-station sessions via custom module: client connects with `?id=<station>`, module calls `receive('/SESSION/OPEN', <path>, {clientId})`.
+5. **Inbound OSC does not loop by default.** A message matching a widget (by `address` + `preArgs` only — sender host:port is ignored) updates the display without re-emitting. `/SET` and user interaction DO emit. `bypass: true` stops a widget's own emissions.
+6. **Canvas widgets (fader/knob/xy) never show their value in the DOM.** Read values via the widget instance, not DOM scraping.
+
+## Quick reference
+
+| Task | Where |
+|---|---|
+| Custom module globals, `app` events, widget enumeration, per-client sessions | [reference/open-stage-control.md](reference/open-stage-control.md) |
+| Inbound matching, feedback/loop rules, reconnect/state behavior | [reference/open-stage-control.md](reference/open-stage-control.md) |
+| Session file JSON format, deployment (`-node.zip`, `--no-gui`, cache/config dirs) | [reference/open-stage-control.md](reference/open-stage-control.md) |
+| Locating/driving/reading widgets in Playwright | [reference/playwright-testing.md](reference/playwright-testing.md) |
+| OSC message encoding, type tags, bundles, UDP vs TCP/SLIP | [reference/osc-protocol.md](reference/osc-protocol.md) |
+| node-red-contrib-osc msg shapes, type casting, udp wiring | [reference/node-red-osc.md](reference/node-red-osc.md) |
+
+## Architecture (this repo)
+
+- Write path: O-S-C widget → UDP → Node-RED `udp in` → `osc` decode → `ship-write` (JSON Pointer admission enforces safety — no new server surface).
+- Feedback path: `ship-read` → RBE filter → per-topic rate limit → `osc` encode → `udp out` → O-S-C (matches widgets by address, no loop).
+- Subscription: O-S-C custom module walks session on load → synthetic subscribe messages → `ship-read` dynamic patterns (see SPEC-0002 in the design repo).
+
+## Common mistakes
+
+| Mistake | Reality |
+|---|---|
+| `npm install -g open-stage-control` | Package doesn't exist; use Framagit `-node.zip` release asset |
+| `--headless` flag | It's `--no-gui` |
+| `page.locator('#my_widget_id')` | DOM id is the internal hash; use `_widget_instance.getProp('id')` |
+| Expecting `?session=x.json` per tablet | Use `?id=<station>` + custom module `/SESSION/OPEN` with `{clientId}` |
+| Fearing feedback loops from `udp out` → O-S-C | Plain inbound match doesn't re-emit; only `/SET`/interaction do |
+| Assuming widget targets constrain inbound matching | Matching is address + preArgs only (targets matter for MIDI and outbound) |
+
+## Verify hands-on (source-verified, not yet runtime-verified)
+
+- The `_widget_instance` Playwright recipe against a live v1.30.3 client (first E2E run validates this).
+- Inner DOM of `toggle`/`push`/`xy` widgets (base structure confirmed; per-type internals not read from source).
+- Whether session files carry a `version`/migration field.

--- a/.claude/skills/osc-controllers/reference/node-red-osc.md
+++ b/.claude/skills/osc-controllers/reference/node-red-osc.md
@@ -1,0 +1,42 @@
+# node-red-contrib-osc
+
+Package: `node-red-contrib-osc` (npm). Maintainer Nicholas Humfrey; latest **v1.1.0, published 2018-06-23** — stable/mature, not actively developed. Wraps the `osc` npm library (`osc.readPacket`/`osc.writePacket`). Transport-agnostic: pair it with `udp in`/`udp out` (this framework), or tcp/websocket/serial (+ `node-red-contrib-slip` for SLIP framing over TCP/serial).
+
+## Decode (Buffer in → object out)
+
+`udp in` (output: Buffer) → `osc` node. If `msg.payload` is a Buffer it decodes with `{metadata: <node setting>, unpackSingleArgs: true}` and sets:
+
+- `msg.topic` = OSC address (e.g. `/reactor/power`)
+- `msg.payload` = the argument(s) — single value unpacked, multiple as array
+- Bundles: `msg.topic = "bundle"`, `msg.payload = packets[]`
+
+With the node's **"include metadata"** checked, each arg is `{type: "f", value: 0.7}` instead of a bare value — enable this when the bridge must distinguish int/float/string.
+
+## Encode (object in → Buffer out)
+
+Non-Buffer payload → the node builds `{address: msg.topic, args: msg.payload}` and outputs a Buffer for `udp out`.
+
+- Address comes from `msg.topic` (or the node's configured path); both empty → error "OSC Path is empty, please provide a path using msg.topic".
+- `payload: ""` → zero-arg message; `payload: null` → single nil (`N`) arg.
+- Bundles pass through with computed `timeTag` (numbers > 10,000,000 treated as absolute timestamps).
+
+## Type casting (int vs float)
+
+The `osc` library infers tags from JS types: integral numbers → `i`, non-integral → `f`. **`1.0` in JS is integral** → sent as int32. To force a float, use a metadata object:
+
+```js
+msg.topic = '/reactor/power'
+msg.payload = { type: 'f', value: 1 }   // forces float32
+return msg
+```
+
+Same convention O-S-C uses in its scripting `send()`. For ship pointer values that are always numeric, forcing `f` avoids int/float mismatches on round values.
+
+## Reference flow shape (this repo)
+
+```
+[udp in :9000] → [osc decode] → [function: topic→JSON pointer] → [ship-write]
+[ship-read] → [rbe] → [delay rate-limit per topic] → [function: pointer→topic] → [osc encode] → [udp out → O-S-C osc-port]
+```
+
+O-S-C matches the fed-back address literally against widget `address` + `preArgs`; the widget updates without re-emitting (no loop).

--- a/.claude/skills/osc-controllers/reference/open-stage-control.md
+++ b/.claude/skills/osc-controllers/reference/open-stage-control.md
@@ -1,0 +1,106 @@
+# Open Stage Control v1.x — integration reference
+
+Verified against v1.30.3 (released 2026-04-28). Canonical repo: `https://framagit.org/jean-emmanuel/open-stage-control` (GitHub is a decommissioned placeholder). Docs: `https://openstagecontrol.ammd.net/docs/`. Client source files are `.mjs` (e.g. `src/client/widgets/common/widget.mjs`).
+
+## Custom module
+
+Loaded with `-c` / `--custom-module`. Lifecycle exports: `init()`, `stop()`, `reload()`, `unload()`, `oscInFilter(data)`, `oscOutFilter(data)`. Filters receive `{address, args, host, port}` (`oscOutFilter` also `clientId`); `args` items are `{value, type}`. Return the object to pass the message through, nothing to drop it.
+
+Modules **hot-reload on file change**; timers and `app` listeners are reset, `module.exports.reload()` is called after, the `global` object persists.
+
+### Globals in the module sandbox
+
+| Global | Purpose |
+|---|---|
+| `app` | EventEmitter of server events (below) |
+| `send(host, port, address, ...args)` | Send OSC/MIDI to any target — NOT limited to widget targets |
+| `receive(host, port, address, ...args, {clientId})` | Simulate an incoming message to clients; `{clientId}` targets one client |
+| `settings.read(name)` | Server option by long name without dashes (`"load"`, `"remote-root"`) |
+| `settings.appAddresses()` | Server HTTP addresses |
+| `loadJSON(path, errCb)` / `saveJSON(path, data, errCb)` | JSON file IO, path relative to module (absolute paths work) |
+| `require(path)` | O-S-C's own splitter for multi-file modules (not Node require) |
+| `nativeRequire(name)` | Real npm modules from a `node_modules` next to the module |
+| `tcpServer`, `restartMidiBackend()` | TCP backend access; MIDI restart |
+| plus | `console`, timers, `__dirname`, `__filename`, `process`, `global` |
+
+### `app` events (from `src/server/node/ipc/callbacks.mjs`)
+
+Callbacks get `(data, client)` where `client` = `{address, id}`. Key events:
+
+- `open` — client connected (no widget data in payload)
+- `close` — client disconnected
+- `sessionSetPath` — **`data.path` = session file path** (absolute, server-resolved)
+- `sessionOpened` — fires after a session opens successfully; `data.path` available
+- `created` / `destroyed` — client lifecycle (reconnect/timeout)
+
+**No event payload contains the widget tree**, and there is no `app.session` / widget registry in the sandbox.
+
+### Enumerating the session's widgets (the supported way)
+
+```js
+module.exports = {
+  init: () => {
+    app.on('sessionSetPath', (data, client) => {
+      const session = loadJSON(data.path)   // absolute path from the event
+      const addresses = []
+      const walk = (w) => {
+        if (w.address) addresses.push({ address: w.address, preArgs: w.preArgs, target: w.target })
+        for (const c of (w.widgets || [])) walk(c)
+        for (const t of (w.tabs || [])) walk(t)
+      }
+      walk(session)
+      // emit synthetic subscribe messages to Node-RED
+      for (const a of addresses) send('NODE_RED_HOST', 9000, '/oscbridge/subscribe', a.address)
+    })
+  }
+}
+```
+
+Alternative: `receive('/EDIT/GET', '<host>:<port>', 'root', {clientId})` makes a client reply with the full widget tree JSON; capture the reply in `oscOutFilter`. Remote-control commands are interpreted by **every** connected client — use `{clientId}` to avoid duplicate replies. Caveat for the `loadJSON` route: a session merely *imported* from a client device may not have a server-side path.
+
+## Per-client sessions from one instance
+
+- URL query options do NOT include session selection (full list: `hdpi`, `forceHdpi`, `doubleTap`, `zoom`, `framerate`, `desyncCanvas`, `lang`, `consoleLength`, `id`, `usePercents`, `noFocus`, `clientSync`, `altTraversing`, `virtualKeyboard`, `notifications`, `title`, `noWarning`).
+- `--load session.json` loads that one session for ALL clients.
+- **Working pattern:** each tablet connects with a stable `?id=<station>`; the custom module maps id → session path and issues `receive('/SESSION/OPEN', path, {clientId: client.id})` on `app.on('open')`.
+- `--remote-root` confines file paths; `--read-only` disables editing; `--remote-saving <regex>` restricts saving hosts.
+
+## Inbound OSC matching & loops
+
+- A received message updates every widget with the **same `address` and same `preArgs`** (ints and round floats treated equal). Remaining args become the value. Sender host:port is irrelevant (except MIDI, which matches on device targets).
+- Inbound update does **not** re-emit. `/SET target id value` sets "as if interacted" and DOES emit. Scripting `set(id, v, {external: true})` simulates an inbound message (implies no send).
+- `bypass: true` on a widget stops its normal emissions (scripted `send()` ignores `bypass`).
+- Client option `clientSync=0` disables cross-client sync; widget target `self` loops a message back to the same client.
+- **Reconnect/reload:** no automatic server-side value store. A reconnecting client syncs from other connected clients sharing `address`+`preArgs`+`targets`; otherwise values reset to defaults unless you use `--state`, `/STATE/SEND` ("make all widgets send their current value"), or a custom-module `/STATE/GET`→`/STATE/SET` pattern. For Starwards, initial-state sync comes from `ship-read` emitting on subscribe — this covers reconnects.
+
+## Remote control API (v1, confirmed)
+
+`/SET`, `/GET`, `/GET/#`, `/EDIT`, `/EDIT/MERGE`, `/EDIT/GET`, `/STATE/GET`, `/STATE/SET`, `/STATE/STORE`, `/STATE/RECALL`, `/STATE/SEND`, `/SESSION/OPEN`, `/TABS`. Sent to the server's OSC input port; replies go to the `target` (`ip:port`) argument.
+
+## Session file format
+
+JSON/JSON5. Root widget of `type: "root"`, children under `widgets` (or `tabs`); each widget has `type`, `id`, and for controls `address`, `preArgs`, `target`, `value`, plus styling props. Minimal example:
+
+```json
+{
+  "type": "root",
+  "id": "root",
+  "widgets": [
+    { "type": "fader", "id": "reactor_power", "address": "/reactor/power", "preArgs": [], "target": [], "value": 0 }
+  ]
+}
+```
+
+Addresses are matched **literally** — O-S-C does not apply OSC pattern-matching wildcards, so JSON-Pointer addresses like `/chainGun/isFiring` pass through untouched. No `version` field observed in sessions (unverified whether one exists); the editor auto-migrates deprecated widgets on open.
+
+## Deployment (Docker/headless)
+
+- **No npm package.** Download the release asset `open-stage-control-[version]-node.zip` from Framagit releases, extract, run `node /path/to/open-stage-control [options]` — pure Node, no Electron, no xvfb.
+- Headless flags: `--no-gui` (no built-in client window). Typical: `node .../open-stage-control --no-gui --load /sessions/demo.json --port 8080 --osc-port 9001 --custom-module /modules/bridge.js`.
+- Ports: `--port` = HTTP (default 8080); `--osc-port` = OSC UDP input (defaults to `--port`); `--tcp-port`/`--tcp-targets` optional.
+- Config/cache live in an `open-stage-control` folder in the OS config location; override with `--cache-dir` and `--config-file` (default `cache-dir/config.json`). Mount sessions + these dirs as volumes.
+- Pin the release version in `docs/DEPENDENCIES.md`.
+
+## MIDI (v1)
+
+Since v1.7.0 no Python/`python-rtmidi` — MIDI uses bundled `open-stage-control-midi` binaries. Widgets target `midi:device_name`; message addresses `/note`, `/control`, `/program`, `/pitch`, `/sysex` as in the docs.

--- a/.claude/skills/osc-controllers/reference/osc-protocol.md
+++ b/.claude/skills/osc-controllers/reference/osc-protocol.md
@@ -1,0 +1,38 @@
+# OSC protocol essentials
+
+Enough to implement/debug the bridge. Spec: CNMAT Open Sound Control 1.0.
+
+## Message encoding
+
+An OSC message = **address pattern** + **type tag string** + **arguments**, each part padded with NULs to 4-byte boundaries.
+
+- Address: ASCII string starting `/`, segments separated by `/` (e.g. `/reactor/power`).
+- Type tag string: starts with `,`, one tag per argument (e.g. `,if` = int then float).
+- Arguments: binary, big-endian, in tag order.
+
+## Type tags
+
+| Tag | Type | Notes |
+|---|---|---|
+| `i` | int32 | |
+| `f` | float32 | Most O-S-C numeric values default to this |
+| `s` | OSC-string | NUL-terminated, 4-byte padded |
+| `b` | blob | int32 size + bytes, padded |
+| `T`/`F` | true/false | no argument bytes |
+| `N` | nil | no argument bytes |
+| `d`, `h`, `t` | double, int64, timetag | extensions, not universally supported |
+
+Int vs float matters: a receiver expecting `f` may ignore `,i` messages. When exact types matter, send explicit `{type, value}` objects (both O-S-C scripting and node-red-contrib-osc support this convention).
+
+## Bundles
+
+`#bundle` + 8-byte timetag + length-prefixed elements (messages or nested bundles). Timetag `1` means "immediately". The bridge doesn't need bundles; expect O-S-C to send plain messages.
+
+## Transport
+
+- **UDP** (default, what this framework uses): one datagram = one packet, no framing needed. Messages > MTU will fragment — keep layouts' values small (they are).
+- **TCP**: byte stream needs framing — OSC 1.0 style uses int32 length prefix; OSC 1.1 uses **SLIP** encoding (END byte `0xC0` delimiters). Node-RED needs `node-red-contrib-slip` between `tcp` nodes and the `osc` node. Only relevant if UDP proves unreliable on the LAN.
+
+## Pattern matching
+
+The OSC spec defines address wildcards (`?` `*` `[]` `{}`) matched by the RECEIVER against its method addresses. Open Stage Control matches addresses **literally** (no wildcard interpretation), so JSON-Pointer addresses are safe. Avoid `#`, spaces, and wildcard characters inside address segments anyway — some tools mis-handle them.

--- a/.claude/skills/osc-controllers/reference/playwright-testing.md
+++ b/.claude/skills/osc-controllers/reference/playwright-testing.md
@@ -1,0 +1,49 @@
+# Testing Open Stage Control widgets with Playwright
+
+Verified from v1.30.3 client source (`src/client/widgets/common/widget.mjs`, `sliders/fader.mjs`, `events/drag.mjs`, `managers/widgets.mjs`). Runtime-verify on first use — these recipes were derived from source, not yet exercised.
+
+## DOM structure
+
+Every widget root:
+
+```html
+<div class="widget {type}-container" id="{hash}" data-widget="{hash}"></div>
+```
+
+- `{hash}` is an **internal uuid**, not the user-defined widget `id`. Do NOT select by `#my_widget_id` — it won't match.
+- Type-level CSS selection works: `.widget.fader-container`, `.widget.push-container`.
+- Each container carries a live back-reference: `el._widget_instance` → the widget object (`getValue()`, `getProp(name)`, `setValue(v, options)`).
+- The client's `widgetManager` (indexes by hash, user id, and OSC address) is module-scoped, NOT on `window` — the `_widget_instance` back-reference is the only stable page-side handle.
+
+## Locating a widget by user id / reading its value
+
+```ts
+const value = await page.evaluate((wantedId) => {
+  for (const el of document.querySelectorAll('[data-widget]')) {
+    const w = (el as any)._widget_instance
+    if (w && w.getProp('id') === wantedId) return w.getValue()
+  }
+  return undefined
+}, 'reactor_power')
+```
+
+Same loop with `w.getProp('address')` locates by OSC address. To get a bounding box for pointer interaction, return `el.getBoundingClientRect()` from the same loop (or set a per-widget `css` class in the session file and use a normal locator).
+
+## Values are NOT in the DOM for canvas widgets
+
+`fader`, `knob`, `xy`, `multixy`, `range`, meters and LEDs draw to `<canvas>`; there is no DOM text/attribute holding the value. DOM widgets (`input`, `text`, `switch`, buttons) do expose value in the DOM. Never scrape canvas pixels — use `_widget_instance.getValue()`.
+
+## Driving widgets
+
+The client listens to **pointer and touch events** (`pointerdown/move/up`, `touchstart/move/end/cancel` — from `events/drag.mjs`), synthesizing internal `draginit`/`drag`/`dragend`.
+
+- Playwright `page.mouse.down/move/up` emits pointer events in Chromium → works for single-pointer widgets (fader, knob, xy, toggle, push). Press/release semantics for momentary buttons: `mouse.down()` … `mouse.up()` are distinct OSC emissions.
+- Multi-touch widgets (`multixy`, per-handle `range`) need touch events — use `page.touchscreen` or `dispatchEvent` with `Touch` init.
+- Precision drag is Ctrl+drag (10× ratio); traversing gestures change drag semantics across widgets — avoid enabling them in test layouts.
+
+## Gotchas
+
+- `hdpi`/`forceHdpi`/`zoom` client URL options scale the canvas — keep them unset (defaults) in test URLs so pointer coordinates map 1:1.
+- Widget `id`s must be unique in the session for the `getProp('id')` lookup to be deterministic.
+- Remote-control commands (`/SET`, `/GET`, `/STATE/SEND`) offer a server-side alternative for assertions, but they exercise the server path, not the touch UI — use them for setup/teardown, not as a substitute for pointer-driven assertions.
+- Session load is async: wait for `[data-widget]` count > 0 (or a known `.widget.fader-container`) before evaluating.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ ship.state.angle = 90      # ❌ Gets overwritten by sync
 | `starwards-colyseus` | State not syncing, @gameField issues |
 | `starwards-ci-debugging` | GitHub Actions CI failures |
 | `starwards-station-ui` | Station screen layout, widgets, input wiring, color system |
+| `osc-controllers` | Open Stage Control layouts/custom modules, Node-RED OSC bridge, tablet controllers, Playwright tests driving O-S-C widgets |
 
 ## Custom Commands
 

--- a/docs/reference/open-stage-control-reference.md
+++ b/docs/reference/open-stage-control-reference.md
@@ -1,0 +1,212 @@
+# Open Stage Control v1.x — Primary-Source Resolution of Open Questions
+
+**Bottom line:** A custom module **cannot enumerate the loaded session's widgets on its own** (no session/widget-tree object is exposed and no event payload carries widget data), but it **can obtain every widget's OSC address/preArgs/target** by capturing the session file path from the `sessionSetPath`/`sessionOpened` events and reading it with `loadJSON`, or by issuing `/EDIT/GET` to its own server via `receive()` — so Q1 is **PARTIAL**. One O-S-C instance **cannot** serve a different session per client via the URL (there is no `session=`/`load=` query option), so Q2 is **REFUTED** for the URL mechanism, but it **is achievable via a custom module** that calls `/SESSION/OPEN` per-client. All findings below are drawn from the v1 docs site (openstagecontrol.ammd.net, MkDocs generator, latest stable **v1.30.3**) and the canonical source on Framagit. Note: `github.com/jean-emmanuel/open-stage-control` is now only a placeholder ("Open Stage Control is no longer on Github"); source lives on Framagit, which I read via raw file fetches.
+
+---
+
+## Q1. Custom module API — can it enumerate the loaded session's widgets?
+
+### Module globals (v1) — from https://openstagecontrol.ammd.net/docs/custom-module/custom-module/
+
+Complete list of globals available in the restricted sandbox:
+
+| Global                                           | Signature / purpose                                                                                                                                            |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `app`                                            | Node.js `EventEmitter`; monitors events from clients. Event names come from `callbacks.mjs`; callbacks receive `data` (object) and `client` (`{address, id}`). |
+| `receive(host, port, address, ...args, options)` | Simulate an incoming OSC/MIDI message to clients. `options` = `{clientId: id}` targets one client. `host`+`port` may be a single colon-joined string.          |
+| `send(host, port, address, ...args)`             | Send OSC/MIDI to a target (same arg convention as `receive`).                                                                                                  |
+| `settings.read(name)`                            | Returns a server option by long name without dashes (e.g. `"send"`, `"load"`, `"read-only"`, `"remote-root"`).                                                 |
+| `settings.appAddresses()`                        | Returns the server's HTTP addresses.                                                                                                                           |
+| `loadJSON(path, errorCallback)`                  | Loads a JSON file; path relative to the custom module's location.                                                                                              |
+| `saveJSON(path, data, errorCallback)`            | Saves an object/array as JSON; path relative to module location.                                                                                               |
+| `require(path)`                                  | O-S-C's own splitter (not Node's `require`) for multi-file modules.                                                                                            |
+| `nativeRequire(moduleName)`                      | Loads native Node/npm modules if a `node_modules` folder exists next to the module.                                                                            |
+| `tcpServer`                                      | Raw access to the server's TCP backend (`tcpServer.clients[ip].port` etc.).                                                                                    |
+| `restartMidiBackend()`                           | Restart the MIDI backend without restarting the server.                                                                                                        |
+| Other JS globals                                 | `console`, `setTimeout`, `clearTimeout`, `setInterval`, `clearInterval`, `__dirname`, `__filename`, `process`, `global`.                                       |
+
+Module lifecycle exports: `init()`, `stop()`, `reload()`, `oscInFilter(data)`, `oscOutFilter(data)`, `unload()`. `oscInFilter`/`oscOutFilter` receive `{address, args, host, port}` (out also has `clientId`); `args` is an array of `{value, type}`.
+
+### App events (v1) — from source `src/server/node/ipc/callbacks.mjs` (Framagit, master)
+
+I read the actual `Callbacks` class. The `app` EventEmitter fires the class's method names. The critical fact: **none of these event payloads contains the session content or the widget tree.** The events and their payloads are:
+
+- **`open(data, clientId)`** — client connected. On connect the server sends `connected`, `sessionList` (recent sessions), `clipboard`, `serverTargets`. If `settings.read('load')` is set and not a hot-reload, it triggers `sessionOpen({path: settings.read('load')})`. Payload has **no** widget data.
+- **`close(data, clientId)`** — client disconnected (empty body).
+- **`created` / `destroyed`** — client created/reconnected, and removed on timeout. `destroyed` clears `this.widgetHashTable[clientId]`.
+- **`sessionSetPath(data, clientId)`** — stores the client's current session file path: `this.ipcServer.clients[clientId].sessionPath = data.path`. **`data.path` is the session file path** — this is the reachable path.
+- **`sessionOpen(data, clientId)`** — reads the session file and sends `sessionOpen` with `{path, fileContent}` to that client. `fileContent` is the parsed session, but this is a **method the server calls / IPC message to the client**, not an `app` event whose payload the module receives with widget data. (The docs' examples listen to `sessionOpened`, which fires *after*.)
+- **`sessionOpened(data, clientId)`** — fires after a session file opens successfully; handles `state` loading and calls `sessionSetPath({path: data.path})`. Docs examples use `app.on('sessionOpened', (data, client)=>{...})` to detect "client connected and in a session."
+- **`addWidget(data, clientId)`** / **`removeWidget(data, clientId)`** — these cache each widget's OSC data server-side in `widgetHashTable`. **`data` = `{hash: 'widget_uuid', data: {target:[...], preArgs:[...], address:'/address', typeTags:'iif'}}`.** This is the one internal channel that carries per-widget address/preArgs/target, but it is an internal IPC callback, not a documented app event, and `preArgs`/`target` may be empty strings.
+- Other events: `clipboard`, `sessionAddToHistory`, `sessionRemoveFromHistory`, `fragmentLoad`, `fileRead`, `fileSave`, `stateOpen`, `sessionSave`, `stateSave`, `syncOsc`, `sendOsc`, `reload`, `reloadCss`, `log`, `error`, `errorLog`, `errorPopup`, `listDir`.
+
+The docs example (Dynamic widget creation) confirms the event names in the public API:
+```js
+app.on('sessionOpened', ()=>{ create_widgets() })
+app.on('sessionSetPath', (e)=>{ if (e.path === '') { create_widgets() } })
+```
+and the client-tracking example:
+```js
+app.on('open',  (data, client)=>{ ...client.id... })
+app.on('close', (data, client)=>{ ...client.id... })
+```
+
+### Can a module enumerate the session's widgets and read each address/preArgs/target?
+
+Three mechanisms evaluated:
+
+1. **A session object reachable from `app`** — **No.** There is no `app.session`, no widget registry, and no global exposing the widget tree in the sandbox. `Callbacks` keeps `widgetHashTable` (server-side OSC cache) but it is not handed to the module. **Blocker: no exposed session/widget object.**
+
+2. **Get the file path from an event and read it with `loadJSON`** — **Yes.** `sessionSetPath`/`sessionOpened` deliver `data.path` (the absolute `.json` session path, resolved server-side). A module can `app.on('sessionSetPath', e => { const session = loadJSON(e.path); /* walk session.widgets recursively */ })`. Each widget node contains its `address`, `preArgs`, and `target` literally (see the session JSON in Q5). This is the most robust enumeration mechanism. Caveat: `loadJSON` resolves paths relative to the module's location, so an absolute path is required (the event supplies one); a client that only *imported* a session from the device filesystem may not set a server-side path.
+
+3. **`/EDIT/GET` remote-control command** — **Confirmed present in v1** (https://openstagecontrol.ammd.net/docs/remote-control/). Two forms:
+   - `/EDIT/GET target id` → replies `/EDIT/GET id data` (JSON-stringified widget **including its children**).
+   - `/EDIT/GET target address preArg1 …` → replies with the widget's data by address.
+   A module **can** invoke it against its own server: call `receive('/EDIT/GET', '<host>:<port>', 'root', {clientId: id})` to make a client emit the whole tree from `root` to the given `target` address, then capture the reply in `oscOutFilter` (the same pattern the docs' "Auto-save client state" example uses with `/STATE/GET`). This yields the full widget tree with every `address`/`preArgs`/`target`. Note the docs warning: remote-control commands are interpreted by **every connected client**, so with multiple clients you get multiple replies — use `{clientId}` to target one.
+
+**Verdict for "a custom module can, on session load or client connect, obtain every widget's OSC address": PARTIAL / effectively CONFIRMED with a mechanism.**
+- Directly from an event payload or a session object: **REFUTED** (no such payload/object).
+- Via `sessionSetPath`→`loadJSON(path)` **or** `/EDIT/GET root` captured in `oscOutFilter`: **CONFIRMED**. Exact blocker for the "direct" path: no in-memory widget registry is exposed to the sandbox; you must read the file or round-trip through a client.
+
+### Hot-reload of custom modules
+**Yes.** Per the Autoreload section: "Custom modules (including submodules loaded with `require()`) are reloaded automatically when they are modified. Upon reload, timers … and event listeners (added to the `app` object) are reset. After each reload the `module.exports.reload()` function (if any) is called. The `global` object persists across reloads." Native modules (`nativeRequire`) may need `module.exports.unload` to release resources (e.g. bound ports).
+
+---
+
+## Q2. One server instance, different session per client URL
+
+### Full list of v1 client URL query options — from https://openstagecontrol.ammd.net/docs/client-options/
+
+Set via `?param=value&param2=value2` on the server URL (or globally via `--client-options`). The **complete** list is:
+
+`hdpi`, `forceHdpi`, `doubleTap`, `zoom`, `framerate`, `desyncCanvas`, `lang` (en/fr/de/pl), `consoleLength`, `id` (client's unique id), `usePercents`, `noFocus`, `clientSync` (0 disables cross-client sync), `altTraversing`, `virtualKeyboard`, `notifications`, `title`, `noWarning`.
+
+**There is no `load=`, `session=`, or equivalent query option.** The URL cannot select which session file a client loads. (The community has explicitly asked for `?session=…`; it does not exist in v1.)
+
+### How sessions actually load
+- Server option **`--load <path.json>`**: "Path to a session file (.json). **All clients** connecting the server will load it." (Server configuration page.) It is one session for all clients — not per-client, and not multiple `--load` values.
+- Path/security rules that govern any session file reading (from `callbacks.mjs`): `remote-root` — non-absolute paths are resolved under `remote-root`, and file browsing/saving is prevented outside it (`if (root && !path.normalize(p).includes(path.normalize(root))) p = root`). `read-only` disables editing/saving. `remote-saving` restricts saving to hosts matching a regex. These constrain where session/state files can be read/written.
+
+### One-instance mechanisms for per-client sessions
+- **URL:** No. (REFUTED for the URL mechanism.)
+- **Custom module (works):** A module can track clients via `app.on('open'/'sessionOpened', (data, client)=>…)` and then issue `receive('/SESSION/OPEN', '/path/to/that-clients-session.json', {clientId: client.id})` — `/SESSION/OPEN path.json` is a documented v1 remote-control command, and `receive(..., {clientId})` targets a single client. This is the supported way to give different clients different sessions from one instance.
+- **Client id routing:** the `id` client option lets you assign stable per-client ids (used with `{clientId}` targeting), but it selects the *client*, not the *session*.
+
+**Verdict for "one O-S-C instance can serve a different session per client URL": REFUTED via URL** (no `session=`/`load=` query parameter exists; `--load` is global to all clients). **However, per-client sessions ARE achievable from one instance via a custom module** using `/SESSION/OPEN` addressed with `{clientId}`.
+
+---
+
+## Q3. Client DOM structure for Playwright testing
+
+**Sourcing note:** The client source files are `.mjs`, not `.js` (e.g. `src/client/widgets/common/widget.mjs`); with the correct extensions the Framagit raw endpoints work. The DOM facts below were verified directly from `widget.mjs`, `sliders/fader.mjs`, `events/drag.mjs`, and `managers/widgets.mjs` (master, ≈v1.30.3).
+
+**Verified DOM structure (from `src/client/widgets/common/widget.mjs`):** every widget's root element is
+
+```html
+<div class="widget {type}-container" id="{hash}" data-widget="{hash}"></div>
+```
+
+where `{hash}` is the widget's internal uuid — **the user-defined widget `id` is NOT in the DOM**; `id`/`data-widget` carry the hash. The container element also gets a direct back-reference: `this.container._widget_instance = this`. The client's `widgetManager` (`src/client/managers/widgets.mjs`) indexes widgets by hash (`this.widgets[hash]`), by user id (`idRoute`), and by OSC address (`addressRoute`), with `getWidgetById(id)` / `getWidgetByAddress(address)` — but it is module-scoped (ES export), **not** exposed on `window`.
+
+**Playwright recipe that follows from this:** locate widgets from `page.evaluate` via the element back-reference, not CSS ids:
+
+```js
+// find a widget by its user-defined id or address, read its value
+const value = await page.evaluate((wantedId) => {
+  for (const el of document.querySelectorAll('[data-widget]')) {
+    const w = el._widget_instance
+    if (w && w.getProp('id') === wantedId) return w.getValue()
+  }
+}, 'reactor_power')
+```
+
+Type-level selectors are available in CSS (`.widget.fader-container`), but stable per-widget selection must go through `_widget_instance.getProp('id')` (or `address`).
+
+**What is verified from primary docs:**
+- **Widgets are a mix of DOM and canvas.** The Properties reference lists canvas-drawn value widgets (fader, knob, xy, multixy, range, the `canvas` widget, visualizers, LEDs) versus DOM widgets (text, input, dropdown/menu, switch, buttons, HTML/SVG). The Canvas widget page confirms sliders/pads/xy render to a `<canvas>` via an `onDraw` script with a `ctx` 2D context; values there are **canvas-only** (not reflected as DOM text).
+- **Unified DOM structure + `:host`.** The changelog (v1.0.0) states v1 "unified (kind of) [the] DOM html structure for widgets" and that "known CSS tricks will require adjustments," and the more-detached-DOM change for nested canvas widgets. The CSS Tips page shows widgets are styled via a **`:host`** selector, i.e. each widget is a custom element / shadow-host-like container, and it explicitly tells users to use the browser DevTools inspector (Ctrl+Shift+C) to find the class names — implying widget id/type is carried on the widget's root element and CSS classes.
+- **Value observability:** For DOM widgets (text/input/switch/button) the value is in the DOM (input value / text content). For canvas widgets (fader/knob/xy/multixy) **the value is not in the DOM** — it is drawn on the canvas.
+- **Client-side JS handle (verified route for canvas values):** The Scripting page documents client-side functions usable for reading values: `get(id)` "Returns the value of the first matching widget" and `getProp(id, name)`. Combined with the remote-control `/GET` command, this means values are reachable programmatically. In practice, from Playwright `page.evaluate`, the reliable value read is via the widget instance rather than DOM scraping: the client's `widgetManager` is module-scoped (not on `window`), but every widget container exposes `el._widget_instance` (verified in `widget.mjs`), giving access to `getValue()` and `getProp()`.
+
+**Input events (verified from `src/client/events/drag.mjs`):** the client listens to **pointer and touch events**, not mouse events: `document.addEventListener('pointerdown'/'pointermove'/'pointerup', ...)` plus `touchstart`/`touchmove`/`touchend`/`touchcancel` (and force-touch variants), and synthesizes internal `draginit`/`drag`/`dragend` events dispatched to widgets. Playwright's `page.mouse` generates pointer events in Chromium, so `mouse.down/move/up` drives single-pointer widgets (fader, knob, xy); multi-touch widgets (multixy, per-handle range) need touch-event dispatch. Fader (`src/client/widgets/sliders/fader.mjs`) confirms canvas rendering — value is drawn to `<canvas>`, never in the DOM; use the `_widget_instance` recipe above for assertions.
+
+**Input semantics (from docs — General mechanics):** Widgets respond to **Mousedown/Tap (at press), Click (at release), Double Click/Double Tap, and Drag** with a 1:1 ratio; `Ctrl`+drag (mouse) or two-finger drag (touch) gives 10× precision. Because the same widgets handle both mouse and touch and support multi-touch (multixy, range) and touch-state events, the client uses **pointer/touch events**, not mouse-only. **Implication for Playwright:** `page.mouse` down/move/up will drive single-pointer widgets (fader/knob/single xy) for basic value changes, but multi-touch widgets (multixy, range per-handle) and any touch-specific behavior require dispatching **pointer/touch events** (e.g. `dispatchEvent` of `pointerdown`/`pointermove`/`pointerup` or touch events), not `page.mouse`. The changelog also notes touch-specific bugs (e.g. `touchend` on detached elements), confirming genuine touch-event handling.
+
+**Recommendation for Playwright value assertions:** don't scrape canvas pixels. Instead read values through the client API in `page.evaluate` (via the documented `get()`/`getProp()` scripting functions or by sending `/GET` and capturing the reply), and drive canvas widgets with pointer-event dispatch at computed coordinates. The root-element structure is now verified from source (see above): select containers by `.widget.{type}-container` / `[data-widget]`, and resolve user ids through `el._widget_instance.getProp('id')`.
+
+---
+
+## Q4. Inbound OSC matching and loop behavior — from https://openstagecontrol.ammd.net/docs/widgets/general-mechanics/
+
+**Inbound matching keys.** "When an osc message is received, it updates every widget that meets the following conditions: same `address`; same `preArgs` (no distinction between integers and round floats). The remaining arguments after `preArgs` are passed to the widget." So matching is on **address + preArgs only**. The sender's `host:port` does **not** affect OSC matching (it matters only for MIDI: "only the widgets that include the emitting MIDI device in their targets will be able to receive it"). Since your widget addresses are literal JSON Pointers like `/reactor/power`, matching is literal on that address string plus any preArgs.
+
+**Does an inbound-updated widget re-emit?** By default **no** — receiving an OSC message updates the widget's displayed value without making it send. The docs distinguish this from `/SET`, which "Set[s] a widget's value **as if it was interacted with** from the interface. This is likely to make it send its value," and from scripting `set(..., {external:true})` which "simulates a value coming from an osc/midi message (implies `send:false`)." So a plain inbound value match does not loop; `/SET` (and user interaction) does emit.
+
+**`bypass` property (v1).** From General mechanics: "Widgets with `bypass` set to `true` will not send synchronization messages to other clients." The changelog adds that scripting `send()` "ignores the widget's `bypass` property (allows bypassing default messages and define custom ones)." So `bypass` suppresses a widget's normal outbound/sync emission (useful to break loops), but explicit `send()` in a script overrides it.
+
+**Global loopback-related server options.** There is no dedicated "loopback" toggle. Relevant controls: the `clientSync` **client** option (0 disables cross-client sync); a widget `target` of **`self`** routes a message back into the same server/client (seen in `sendOsc` in `callbacks.mjs`: `if (targets[i] === 'self') this.ipcServer.send('receiveOsc', data, clientId)`); and the server `send` default targets. To avoid loops with Node-RED, keep your game-server return path on a distinct address or use `bypass`/`{send:false}`.
+
+**On client reload/reconnect — does the server push current values?** Not automatically from a live in-memory store; O-S-C is largely stateless per client. Values are re-established by: (a) the `state`/`--load` mechanism — `sessionOpened` loads a `.state` file if `--state` is set, and only makes the client send if it's the sole active client; (b) **cross-client sync** — if another client is already connected, the reconnecting client syncs widgets that share `address`+`preArgs`+`targets`; (c) explicit `/STATE/SEND` ("Make all widgets send their current value") or a custom-module `/STATE/GET`+`/STATE/SET` pattern (documented example). So a fresh reconnect with no other clients and no `--state` file starts at default values unless you push state via a custom module or `/STATE/*`.
+
+---
+
+## Q5. Quick facts
+
+**Current stable v1.x.** **v1.30.3, released 2026-04-28** (Framagit releases API; preceding releases: v1.30.2 2026-03-02, v1.30.1 2026-01-08, v1.30.0 2025-12-30).
+
+**Distribution + headless (no-Electron) run.**
+
+- **There is NO npm package.** `registry.npmjs.org/open-stage-control` returns 404 and registry search has no such package (verified 2026-07-04); the `package.json` name is repo-internal only. Distribution is via Framagit release assets: platform binaries and **`open-stage-control-[version]-node.zip`** for pure-Node deployments. ⚠️ **Spec impact:** SPEC-0002 Open Question 5's default ("official Node image running the `open-stage-control` npm package") is not viable — the Docker image must download/extract the `-node.zip` release asset (or build from source) instead.
+- Two headless modes (from Running with node):
+  - **Lite headless via Electron's Node:** `ELECTRON_RUN_AS_NODE=1 open-stage-control /path/to/open-stage-control/resources/app/ [options]` (lower CPU/RAM).
+  - **Pure Node.js (no Electron):** download `open-stage-control-[version]-node.zip`, extract, then `node /path/to/open-stage-control [options]`. From electron package: `node …/resources/app`; from sources: `node …/app`.
+  - Add `--no-gui` to disable the built-in client window (headless server). Full headless launch example from the docs: `open-stage-control --no-gui --load path/to/session.json --theme path/to/theme.css`.
+- **Config/session file locations (for Docker volumes):** In v1, "cache and config files are now stored in a folder named **`open-stage-control`** (located in the system's default location for config files). The `.open-stage-control` [dotfile] is no longer used." Override with `--cache-dir` (browser cache + localStorage) and `--config-file` (session history + launcher config; defaults to `cache-dir/config.json`). For Docker, mount your session `.json` files at a fixed path and pass `--load`, and volume-mount `--cache-dir`/`--config-file` to persist history/config. Electron headless in Docker needs a virtual framebuffer (`xvfb-run`); the pure-Node package avoids that.
+
+**Session file format (minimal real v1 session).** Sessions are JSON/JSON5. A session is a single root widget (type `root`/panel) whose `widgets` array holds children; each widget carries `type`, `id`, and (for controls) `address`, `preArgs`, `target`. A minimal illustrative v1 session with a root and one fader with an address:
+```json
+{
+  "type": "root",
+  "id": "root",
+  "widgets": [
+    {
+      "type": "fader",
+      "id": "reactor_power",
+      "address": "/reactor/power",
+      "preArgs": [],
+      "target": [],
+      "value": 0
+    }
+  ]
+}
+```
+This structure is confirmed by the docs' Dynamic-widget-creation example (widgets nested under a container with `type`, `id`, `address`, `preArgs`) and by cookbook session widget objects (e.g. `{ "mode":"momentary", "address":"/cue/#{$+1}/start", "label":"Q#{$+1}" }`). **Migration/version fields:** I did not find an explicit `version` key documented in the session schema in v1 primary sources — **UNVERIFIED**; the editor auto-migrates deprecated widgets (e.g. multipush→matrix) on open. Widget matching in your Node-RED bridge should key on the literal `address` string (JSON-Pointer-style like `/reactor/power`) plus `preArgs`.
+
+**node-red-contrib-osc.** Maintainer **njh (Nicholas Humfrey) / Nathanaël Lécaudé**, Apache-2.0. Repo `github.com/njh/node-red-contrib-osc` (default branch `main`). **Maintenance:** low-activity/mature — 56 commits total, copyright line reads "2014–2016," and the last substantive change was the v1.0 transport-agnostic rewrite; treat it as **stable but not actively developed**. Latest npm publish: **v1.1.0, 2018-06-23** (npm registry API, verified 2026-07-04); maintainer Nicholas Humfrey. It depends on the `osc` npm package (`require('osc')`, `osc.readPacket`/`osc.writePacket`).
+
+Exact msg shapes (verified from `osc.js` source + `osc.html`):
+- **Decode (Buffer → object):** if `msg.payload` is a `Buffer`, the node decodes with `osc.readPacket(payload, {metadata: node.metadata, unpackSingleArgs: true})`, then sets **`msg.topic` = OSC address** and **`msg.payload` = args**. Bundles set `msg.topic = "bundle"` and `msg.payload = raw.packets`.
+- **"Include metadata" ON:** each value becomes `{ "type": "f", "value": 33.4 }` (type tag + value). OFF: raw values (single args unpacked).
+- **Encode (object → Buffer):** if payload is not a Buffer, the node builds `packet = {address: msg.topic, args: msg.payload}` and outputs `msg.payload = Buffer(osc.writePacket(packet))`. Special cases: `payload === ""` → `{address, args: []}`; `payload === null` → args `{type:"N", value:null}`; bundles pass through with a computed `timeTag` (values > 10,000,000 treated as absolute timestamps). The address must come from `msg.topic` (or the node's configured `path`); if both are empty the node errors: "OSC Path is empty, please provide a path using msg.topic."
+- **int vs float casting:** the underlying `osc` library infers type tags from JS types (integers → `i`, floats → `f`) unless you pass explicit `{type, value}` metadata objects. To force a float or int, send args as metadata objects (e.g. `{type:"f", value:1}`) — matching O-S-C's own convention where `send('/address', {type:'i', value:1})` sends an integer.
+- **Documented pairing:** the OSC node is **transport-independent** — "you will need to use it with Node-RED's built-in input and output objects like **udp, tcp, websocket or serial**." Standard pattern: **`udp in` → `osc` (decode) → your flow**, and **your flow → `osc` (encode) → `udp out`**. For OSC-over-TCP/serial, add `node-red-contrib-slip` (SLIP decoder before / encoder after the OSC node). This is exactly the UDP-in/UDP-out bridge your architecture needs between tablets/O-S-C and the game server.
+
+---
+
+## Unverified items
+
+Previously-unverified items closed on 2026-07-04 by direct source verification (the client sources are `.mjs`, not `.js` — with correct paths Framagit raw works; npm was checked via the registry JSON API, which is not bot-blocked): widget DOM structure and id attribute (Q3), input event types (Q3), v1.30.3 release date (Q5), npm status of both packages (Q5 — `open-stage-control` turned out not to exist on npm at all).
+
+Still open:
+
+- **Q3:** exact DOM internals of `toggle`/`push`/`xy` widgets (only base class + fader read from source; same base structure applies, per-type inner elements unverified).
+- **Q5 session-file `version`/migration field** — no explicit version key found in v1 primary docs/examples; UNVERIFIED whether one exists.
+
+---
+
+## Summary verdict table
+
+| Question                                                                                      | Verdict               | One-line evidence                                                                                                                                                                                                                                                          |
+| --------------------------------------------------------------------------------------------- | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Q1** — custom module can, on session load/client connect, obtain every widget's OSC address | **PARTIAL**           | No exposed session/widget-tree object or event payload with widget data (`callbacks.mjs`), BUT achievable via `sessionSetPath`/`sessionOpened` → `loadJSON(path)`, or `receive('/EDIT/GET', target, 'root', {clientId})` captured in `oscOutFilter` (remote-control docs). |
+| **Q2** — one O-S-C instance can serve a different session per client URL                      | **REFUTED (via URL)** | Client-options page lists no `session=`/`load=` query param; `--load` loads one session for "all clients" (server-config page). Per-client sessions are only possible via a custom module calling `/SESSION/OPEN` with `{clientId}`.                                       |


### PR DESCRIPTION
## Summary

Knowledge-base deliverable for the OSC controller framework (design-repo SPEC-0002): touch/MIDI control surfaces via Open Stage Control ⇄ Node-RED ⇄ Starwards, with OSC address = admitted JSON Pointer.

- **New skill `.claude/skills/osc-controllers/`** (github-api skill-with-reference pattern): SKILL.md with the critical facts + `reference/` docs covering Open Stage Control v1.30.3 (custom module API, per-client sessions via `/SESSION/OPEN`+`clientId`, inbound matching/loop rules, session format, headless deployment), OSC protocol essentials, `node-red-contrib-osc` msg shapes, and Playwright recipes for driving/reading O-S-C widgets.
- **`docs/reference/open-stage-control-reference.md`**: the primary-source research record backing the skill (Framagit source + official v1 docs; every claim cited, residual unknowns marked).
- **CLAUDE.md**: skill registered in the skills table.
- **`.claude/settings.json`**: allow `git fetch`/`git pull`.

Key verified corrections over common assumptions: O-S-C is **not** on npm (deploy from the `-node.zip` Framagit release asset, `--no-gui` not `--headless`); widget DOM ids are internal hashes (tests must use `el._widget_instance`); no per-URL session query param exists.

## Test plan

- [x] Skill retrieval-tested TDD-style: baseline agent without the skill failed/hallucinated on 4 of 5 key questions; with the skill all 5 answered correctly.
- [x] All O-S-C facts verified against v1.30.3 primary sources (source files, docs, release/npm registry APIs).
- [ ] Playwright recipes are source-derived; runtime validation lands with the SPEC-0002 E2E work (flagged in the skill's "verify hands-on" list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)