### PR TITLE
docs: update design docs from 2026-07-04 talk and issue triage

### DIFF
--- a/docs/bridge-playtest/decisions.md
+++ b/docs/bridge-playtest/decisions.md
@@ -2,6 +2,23 @@
 
 Confirmed decisions only. Candidates and drafts live in [`proposals.md`](proposals.md).
 
+## 2026-07-04 — Next-step priorities
+
+Agreed order of upcoming work (Amir + Daniel, 2026-07-04):
+
+1. **Merge the ammo-type × armor-type damage metrics.** Land the new per-pair damage mechanic (see the 2026-05-03 armor×ammo decision below). Daniel's concrete draft is [#1929](https://github.com/starwards/starwards/issues/1929) (5 armor types × 8 ammo types, full damage matrix); implementation is pending in [PR #1932](https://github.com/starwards/starwards/pull/1932). Merging that PR is the immediate next step.
+2. **Design the player ship — the corvette (Gravitas).** Make it interesting and durable for play: it must survive and stay engaging across a full session, not just a dogfight.
+3. **Add the Signals radar beam.** The directional beam at the Signals station (see the tier-2 EW scan beam in the 2026-05-03 scan-tiers decision below).
+
+Future features discussed in the same talk (probes, railgun, torpedo) are drafted in [`proposals.md`](proposals.md), not committed to this milestone.
+
+**Open design issues.** Two questions remain unresolved after the priorities above:
+
+1. **Ship kill condition — how do you destroy a ship?** What ends a ship in play? Needs to be reconciled with the standing "malfunction over destruction" philosophy (ships never auto-explode; TPK is a GM decision — see [`../design/mechanics/armor-and-damage.md`](../design/mechanics/armor-and-damage.md)). With durable player ships (the Gravitas corvette) and the new ammo×armor damage model, the win/loss condition of combat needs an explicit design.
+2. **Weapons officer and multiple PDCs — controlling or managing?** If the ship carries several PDCs, what is the weapons officer's game experience? Directly aiming/firing one at a time vs. a management layer (assigning targets/arcs/priorities to semi-autonomous mounts). Relates to the PDC + Brace cascade proposal in [`proposals.md`](proposals.md) (currently out of MVP scope per the 2026-05-03 scope decision).
+
+**Status.** Priorities agreed (Daniel, 2026-07-04). The two design issues above are open — no direction chosen yet.
+
 ## 2026-05-03 — MVP scope (next milestone)
 
 **In scope.** Only items confirmed in this file.
@@ -22,7 +39,7 @@ Confirmed decisions only. Candidates and drafts live in [`proposals.md`](proposa
 - **Weapons**: receives the call, selects matching ammo, fires.
 - Replaces the "shield frequency equivalent" slot in the gap-closing plan.
 
-**Counts.** Multiple armor types and multiple ammo types (missiles + cannon shells). Concrete counts owned by Daniel — see his draft when ready. Intent: asymmetric ammo↔armor mapping (no clean 1:1) so some ammo is strong vs. multiple armors and weak vs. others, forcing real Weapons judgment rather than lookup.
+**Counts.** Multiple armor types and multiple ammo types (missiles + cannon shells). Concrete counts owned by Daniel — draft landed as [#1929](https://github.com/starwards/starwards/issues/1929) (5 armor types, 8 ammo types, Resist/Normal/Vulnerable/Critical/Ignores matrix). Intent: asymmetric ammo↔armor mapping (no clean 1:1) so some ammo is strong vs. multiple armors and weak vs. others, forcing real Weapons judgment rather than lookup.
 
 **Status.** Direction agreed (Daniel, 2026-05-03). Open: full per-pair damage matrix, partial-match curve shape, per-ammo magazine slot allocation, in-flight reload swap rules.
 

--- a/docs/bridge-playtest/proposals.md
+++ b/docs/bridge-playtest/proposals.md
@@ -38,6 +38,18 @@ Hard maneuvers and broken sight lines drop the tier. The details live on the Sig
 
 Once a target is scanned deep enough, hack becomes available — soften enemy weapons, engines, sensors, or reactor for thirty to sixty seconds. The action is short two-or-three-second code bursts, never absorbing. The skill lives in the *coordination*: engineering can power-dump on the mark for a multiplier, the pilot has to hold range, the captain picks which enemy system softens which of our problems. A successful hack is the Signals→Weapons→Pilot offensive cascade — the mirror of the Brace cascade running the other direction. The skill ceiling is *when and what*, not *how fast*. Resist making it a fast-typing mini-game (that's how EE got its comms islands).
 
+## Probe capability (complements the radar beam)
+
+*Added 2026-07-04 (talk with Daniel).* Launchable probes that complement the Signals radar/scan beam by covering what a line-of-sight beam cannot: looking **behind obstacles** and **inside nebulae**, etc. The beam is the ship's directional sensing tool; the probe is the remote one — send it where the beam can't reach. Relates to the existing probe scope in the Relay station design (post-first-event expansion).
+
+## Railgun (beam-like line weapon)
+
+*Added 2026-07-04 (talk with Daniel).* The railgun behaves like a laser beam: a **line that just cuts through everything** along its path — closer to hitscan than a projectile. Distinct from the earlier "charge-time medium-range weapon" sketch; the defining trait is the piercing line. Damage model, charge/heat cost, and how it interacts with armor types TBD.
+
+## Torpedo (large-charge, high-maneuverability drone)
+
+*Added 2026-07-04 (talk with Daniel).* The torpedo is the railgun's opposite: a **high-speed, large-charge drone-like projectile with high maneuverability**. Where the railgun is an instant line, the torpedo is a guided object that flies, turns hard, and delivers a big warhead. Refines the existing homing-missile torpedo concept; specifics (speed, tracking, counterplay such as PDC interception) TBD.
+
 ---
 
 ## Proposed build order

--- a/docs/design/infrastructure/distribution.md
+++ b/docs/design/infrastructure/distribution.md
@@ -10,8 +10,7 @@
 
 ## What's needed
 
-- [ ] Versioned downloadable binaries ([#1295](https://github.com/starwards/starwards/issues/1295)) — tagged releases with download links
-- [ ] Accessible executable download ([#832](https://github.com/starwards/starwards/issues/832)) — easy for non-technical LARP organizers
+- [ ] Versioned downloadable binaries ([#1295](https://github.com/starwards/starwards/issues/1295)) — GitHub Release binaries on version tags, version in lobby, README download instructions (absorbed #832; rewritten agent-ready 2026-07-05)
 - [ ] Event setup documentation — step-by-step guide for LAN deployment
 - [ ] Network topology guide — what hardware, how to connect, what ports
 

--- a/docs/design/infrastructure/distribution.md
+++ b/docs/design/infrastructure/distribution.md
@@ -10,7 +10,7 @@
 
 ## What's needed
 
-- [ ] Versioned downloadable binaries ([#1295](https://github.com/starwards/starwards/issues/1295)) — GitHub Release binaries on version tags, version in lobby, README download instructions (absorbed #832; rewritten agent-ready 2026-07-05)
+- [ ] Versioned downloadable binaries ([#1295](https://github.com/starwards/starwards/issues/1295)) — GitHub Release binaries on version tags, version in lobby, README download instructions
 - [ ] Event setup documentation — step-by-step guide for LAN deployment
 - [ ] Network topology guide — what hardware, how to connect, what ports
 

--- a/docs/design/issue-review.md
+++ b/docs/design/issue-review.md
@@ -106,14 +106,13 @@ These are 3-4 year old design sketches. Some have been superseded by the detaile
 | [#1001](https://github.com/starwards/starwards/issues/1001) | Emissions signature (WIP) | **Keep** — not yet absorbed into MS3 design. Post-event feature. |
 | [#969](https://github.com/starwards/starwards/issues/969) | Radar improvements (mega-task draft) | **Superseded** — scan levels design in docs covers this. Close with link to docs. |
 | [#967](https://github.com/starwards/starwards/issues/967) | Name ship systems models | **Still relevant** — display names in tweak panel. Quick win. |
-| [#939](https://github.com/starwards/starwards/issues/939) | Scan minigame idea | Closed 2026-07-05 — superseded by the EW scan beam design (`docs/bridge-playtest/decisions.md`) |
 | [#882](https://github.com/starwards/starwards/issues/882) | Constants panel for ship model design | **Still relevant** — needed for #546 (multiple ship models). |
 | [#870](https://github.com/starwards/starwards/issues/870) | Dynamic map/config/asset loading | **Critical for events** but not MS3. Needed for reusable scenarios. |
 
 **Recommendations:**
 1. **Close #969** — superseded by scan levels + signals jobs design
 2. **Keep #882 and #870** — both needed, just not on critical path
-3. **Label #1001** as `post-event` (#939 closed 2026-07-05, superseded by the EW scan beam design)
+3. **Label #1001** as `post-event`
 
 ---
 
@@ -168,7 +167,6 @@ These are 3-4 year old design sketches. Some have been superseded by the detaile
 | [#835](https://github.com/starwards/starwards/issues/835) | Usage instructions | **Important for events** — players need onboarding docs |
 | [#834](https://github.com/starwards/starwards/issues/834) | Keys configuration | Keep — different events may need different keybinds |
 | [#833](https://github.com/starwards/starwards/issues/833) | Armor plates on tactical radar | Keep — combined view for single-pilot |
-| [#832](https://github.com/starwards/starwards/issues/832) | Accessible executable download | Closed 2026-07-05 — merged into [#1295](https://github.com/starwards/starwards/issues/1295) (rewritten agent-ready) |
 | [#551](https://github.com/starwards/starwards/issues/551) | AI handicap variables | Keep — GM needs difficulty tuning |
 | [#548](https://github.com/starwards/starwards/issues/548) | Cargo system | Keep — explicitly deferred post-event |
 

--- a/docs/design/issue-review.md
+++ b/docs/design/issue-review.md
@@ -106,14 +106,14 @@ These are 3-4 year old design sketches. Some have been superseded by the detaile
 | [#1001](https://github.com/starwards/starwards/issues/1001) | Emissions signature (WIP) | **Keep** — not yet absorbed into MS3 design. Post-event feature. |
 | [#969](https://github.com/starwards/starwards/issues/969) | Radar improvements (mega-task draft) | **Superseded** — scan levels design in docs covers this. Close with link to docs. |
 | [#967](https://github.com/starwards/starwards/issues/967) | Name ship systems models | **Still relevant** — display names in tweak panel. Quick win. |
-| [#939](https://github.com/starwards/starwards/issues/939) | Scan minigame idea | **Keep as idea** — explicitly deferred post-event. Label as such. |
+| [#939](https://github.com/starwards/starwards/issues/939) | Scan minigame idea | Closed 2026-07-05 — superseded by the EW scan beam design (`docs/bridge-playtest/decisions.md`) |
 | [#882](https://github.com/starwards/starwards/issues/882) | Constants panel for ship model design | **Still relevant** — needed for #546 (multiple ship models). |
 | [#870](https://github.com/starwards/starwards/issues/870) | Dynamic map/config/asset loading | **Critical for events** but not MS3. Needed for reusable scenarios. |
 
 **Recommendations:**
 1. **Close #969** — superseded by scan levels + signals jobs design
 2. **Keep #882 and #870** — both needed, just not on critical path
-3. **Label #939 and #1001** as `post-event`
+3. **Label #1001** as `post-event` (#939 closed 2026-07-05, superseded by the EW scan beam design)
 
 ---
 
@@ -168,7 +168,7 @@ These are 3-4 year old design sketches. Some have been superseded by the detaile
 | [#835](https://github.com/starwards/starwards/issues/835) | Usage instructions | **Important for events** — players need onboarding docs |
 | [#834](https://github.com/starwards/starwards/issues/834) | Keys configuration | Keep — different events may need different keybinds |
 | [#833](https://github.com/starwards/starwards/issues/833) | Armor plates on tactical radar | Keep — combined view for single-pilot |
-| [#832](https://github.com/starwards/starwards/issues/832) | Accessible executable download | Keep — distribution story |
+| [#832](https://github.com/starwards/starwards/issues/832) | Accessible executable download | Closed 2026-07-05 — merged into [#1295](https://github.com/starwards/starwards/issues/1295) (rewritten agent-ready) |
 | [#551](https://github.com/starwards/starwards/issues/551) | AI handicap variables | Keep — GM needs difficulty tuning |
 | [#548](https://github.com/starwards/starwards/issues/548) | Cargo system | Keep — explicitly deferred post-event |
 

--- a/docs/design/roadmap.md
+++ b/docs/design/roadmap.md
@@ -28,12 +28,9 @@ Work items ordered by "what unblocks a playable event soonest":
 | Priority | Item | Why |
 |----------|------|-----|
 | 1 | **Ship models** ([#546](https://github.com/starwards/starwards/issues/546)) | Can't crew a corvette without corvette ships |
-| 2 | ~~**Docking**~~ ([#539](https://github.com/starwards/starwards/issues/539)) — **Done**, closed 2026-07-05 | Ship-in-ship docking landed; dock-master ([#538](https://github.com/starwards/starwards/issues/538)) remains |
-| 3 | **Signals station UI** ([#1208](https://github.com/starwards/starwards/issues/1208)) | Wire up the jobs system to a playable station |
-| 4 | **Pre-event bugs** ([#866](https://github.com/starwards/starwards/issues/866), [#1002](https://github.com/starwards/starwards/issues/1002), [#748](https://github.com/starwards/starwards/issues/748)) | Things that will break during play |
-| 5 | **Scenario file loading** ([#870](https://github.com/starwards/starwards/issues/870)) | Externalize maps so organizers can author scenarios |
-| 6 | **Room lifecycle** ([#1238](https://github.com/starwards/starwards/issues/1238)) | Stale rooms during multi-hour event = chaos |
-| 7 | **Usage docs** ([#835](https://github.com/starwards/starwards/issues/835)) | Players need onboarding |
+| 2 | **Signals station UI** ([#1208](https://github.com/starwards/starwards/issues/1208)) | Wire up the jobs system to a playable station |
+| 3 | **Scenario file loading** ([#870](https://github.com/starwards/starwards/issues/870)) | Externalize maps so organizers can author scenarios |
+| 4 | **Usage docs** ([#835](https://github.com/starwards/starwards/issues/835)) | Players need onboarding |
 
 ### Tier 3: Expansion (post-first-event)
 - [ ] **Warp frequency topology** ([#1182](https://github.com/starwards/starwards/issues/1182)) — procedural efficiency zones
@@ -41,7 +38,6 @@ Work items ordered by "what unblocks a playable event soonest":
 - [ ] **Relay station** ([#1211](https://github.com/starwards/starwards/issues/1211)) — probes, route coordination
 - [ ] **Repair system** — 3-tier system, Node-RED integration
 - [x] **Hull damage** ([#1187](https://github.com/starwards/starwards/issues/1187)) — IoT alerts
-- ~~**Scan minigame** ([#939](https://github.com/starwards/starwards/issues/939))~~ — closed 2026-07-05, superseded by the EW scan beam design (`docs/bridge-playtest/decisions.md`)
 - [ ] **Cargo system** ([#548](https://github.com/starwards/starwards/issues/548))
 
 ### Pre-Event Gate
@@ -62,9 +58,8 @@ Warp Topology (#1182)
   └─► Navigator Radar (#1262)
        └─► Navigator Station (#1261)
 
-Docking (#539)
-  └─► Dock Master (#538)
-       └─► Repair features
+Dock Master (#538)
+  └─► Repair features
 ```
 
 ## History
@@ -86,4 +81,3 @@ Features explicitly deferred until after the first LARP event:
 - Cargo system ([#548](https://github.com/starwards/starwards/issues/548))
 - Fighters as playable ships (currently only NPC)
 - 3D visualization (separate Unity client)
-- ~~Scan minigame ([#939](https://github.com/starwards/starwards/issues/939))~~ — superseded by the EW scan beam design

--- a/docs/design/roadmap.md
+++ b/docs/design/roadmap.md
@@ -28,7 +28,7 @@ Work items ordered by "what unblocks a playable event soonest":
 | Priority | Item | Why |
 |----------|------|-----|
 | 1 | **Ship models** ([#546](https://github.com/starwards/starwards/issues/546)) | Can't crew a corvette without corvette ships |
-| 2 | **Docking** ([#539](https://github.com/starwards/starwards/issues/539)) | Stations are ships; repair/resupply requires docking |
+| 2 | ~~**Docking**~~ ([#539](https://github.com/starwards/starwards/issues/539)) — **Done**, closed 2026-07-05 | Ship-in-ship docking landed; dock-master ([#538](https://github.com/starwards/starwards/issues/538)) remains |
 | 3 | **Signals station UI** ([#1208](https://github.com/starwards/starwards/issues/1208)) | Wire up the jobs system to a playable station |
 | 4 | **Pre-event bugs** ([#866](https://github.com/starwards/starwards/issues/866), [#1002](https://github.com/starwards/starwards/issues/1002), [#748](https://github.com/starwards/starwards/issues/748)) | Things that will break during play |
 | 5 | **Scenario file loading** ([#870](https://github.com/starwards/starwards/issues/870)) | Externalize maps so organizers can author scenarios |
@@ -41,7 +41,7 @@ Work items ordered by "what unblocks a playable event soonest":
 - [ ] **Relay station** ([#1211](https://github.com/starwards/starwards/issues/1211)) — probes, route coordination
 - [ ] **Repair system** — 3-tier system, Node-RED integration
 - [x] **Hull damage** ([#1187](https://github.com/starwards/starwards/issues/1187)) — IoT alerts
-- [ ] **Scan minigame** ([#939](https://github.com/starwards/starwards/issues/939))
+- ~~**Scan minigame** ([#939](https://github.com/starwards/starwards/issues/939))~~ — closed 2026-07-05, superseded by the EW scan beam design (`docs/bridge-playtest/decisions.md`)
 - [ ] **Cargo system** ([#548](https://github.com/starwards/starwards/issues/548))
 
 ### Pre-Event Gate
@@ -86,4 +86,4 @@ Features explicitly deferred until after the first LARP event:
 - Cargo system ([#548](https://github.com/starwards/starwards/issues/548))
 - Fighters as playable ships (currently only NPC)
 - 3D visualization (separate Unity client)
-- Scan minigame ([#939](https://github.com/starwards/starwards/issues/939))
+- ~~Scan minigame ([#939](https://github.com/starwards/starwards/issues/939))~~ — superseded by the EW scan beam design

--- a/docs/design/status.md
+++ b/docs/design/status.md
@@ -40,7 +40,7 @@ _None._
 
 | Area | Status | Key Issues | Notes |
 |------|--------|------------|-------|
-| [Distribution](infrastructure/distribution.md) | Partial | [#1295](https://github.com/starwards/starwards/issues/1295), [#832](https://github.com/starwards/starwards/issues/832) | pkg.js builds work; versioned downloads not done |
+| [Distribution](infrastructure/distribution.md) | Partial | [#1295](https://github.com/starwards/starwards/issues/1295) | pkg.js builds work; versioned downloads not done (#832 merged into #1295, now agent-ready) |
 | [Scenario loading](infrastructure/scenarios.md) | Planned | [#870](https://github.com/starwards/starwards/issues/870) | TypeScript scenario files loaded from disk |
 | [Networking](infrastructure/networking.md) | Done | — | Colyseus multiplayer, LAN-ready |
 | Node-RED integration | Done | [#1294](https://github.com/starwards/starwards/issues/1294) | IoT bridge via colyseus-events |

--- a/docs/design/status.md
+++ b/docs/design/status.md
@@ -40,7 +40,7 @@ _None._
 
 | Area | Status | Key Issues | Notes |
 |------|--------|------------|-------|
-| [Distribution](infrastructure/distribution.md) | Partial | [#1295](https://github.com/starwards/starwards/issues/1295) | pkg.js builds work; versioned downloads not done (#832 merged into #1295, now agent-ready) |
+| [Distribution](infrastructure/distribution.md) | Partial | [#1295](https://github.com/starwards/starwards/issues/1295) | pkg.js builds work; versioned downloads not done |
 | [Scenario loading](infrastructure/scenarios.md) | Planned | [#870](https://github.com/starwards/starwards/issues/870) | TypeScript scenario files loaded from disk |
 | [Networking](infrastructure/networking.md) | Done | — | Colyseus multiplayer, LAN-ready |
 | Node-RED integration | Done | [#1294](https://github.com/starwards/starwards/issues/1294) | IoT bridge via colyseus-events |


### PR DESCRIPTION
## Summary
- Records next-step priorities and two open design questions from the Amir/Daniel talk (2026-07-04): ammo×armor damage merge, corvette (Gravitas) design, Signals radar beam
- Adds probe, railgun, and torpedo proposals to `docs/bridge-playtest/proposals.md`
- Closes out resolved/superseded issues in status/roadmap/issue-review docs: #939 (superseded by EW scan beam), #832 (merged into #1295), #539 (docking done)

## Test plan
- [ ] Docs-only change; no build/test impact