### PR TITLE
test: silence Colyseus room-lifecycle logging in server specs (closes #1948)

### DIFF
--- a/modules/server/src/server.ts
+++ b/modules/server/src/server.ts
@@ -28,7 +28,13 @@ export async function server(port: number, staticDirs: string | string[], manage
     const app = express();
     app.use(express.json() as express.RequestHandler);
     const httpServer = http.createServer(app);
-    const gameServer = new Server({ transport: new WebSocketTransport({ server: httpServer }), greet: false });
+    const gameServer = new Server({
+        transport: new WebSocketTransport({ server: httpServer }),
+        greet: false,
+        ...(process.env.JEST_WORKER_ID
+            ? { logger: { debug: () => {}, error: () => {}, info: () => {}, trace: () => {}, warn: () => {} } }
+            : {}),
+    });
 
     gameServer.define('space', SpaceRoom);
     gameServer.define('admin', AdminRoom);

--- a/modules/server/src/test/colyseus-logging.spec.ts
+++ b/modules/server/src/test/colyseus-logging.spec.ts
@@ -1,0 +1,19 @@
+import { makeDriver } from './driver';
+
+// This test verifies that Colyseus lifecycle logging is suppressed when running
+// under Jest (JEST_WORKER_ID is set), so test output stays clean.
+describe('Colyseus logger suppression', () => {
+    makeDriver();
+
+    it('does not call console when Colyseus logger fires under JEST_WORKER_ID', () => {
+        expect(process.env.JEST_WORKER_ID).toBeDefined();
+        const consoleSpy = jest.spyOn(console, 'info').mockReturnValue(undefined);
+        // Access logger via module reference (not destructured import) so we see
+        // the current logger value after server() has set it in beforeEach.
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const colyseusCore = require('@colyseus/core') as { logger: { info: (...args: unknown[]) => void } };
+        colyseusCore.logger.info('room lifecycle message');
+        expect(consoleSpy).not.toHaveBeenCalled();
+        consoleSpy.mockRestore();
+    });
+});


### PR DESCRIPTION
Closes #1948

## Summary

- Pass a no-op logger (`{ debug, error, info, trace, warn: () => {} }`) to the Colyseus `Server` constructor when `JEST_WORKER_ID` is set (i.e., running under Jest). This causes Colyseus to call `setLogger(noopLogger)` globally for the worker, suppressing all room lifecycle `console.info`/`console.warn`/`console.debug` output.
- Dev/prod server logging is completely unchanged — the no-op logger is only applied when `JEST_WORKER_ID` is defined.
- Adds `colyseus-logging.spec.ts` with a regression test: after `server()` runs (via `makeDriver()`'s `beforeEach`), verifies that `colyseusCore.logger.info()` does not reach `console.info`.

## MUST fill in (do not delete this section)

State sync invariants:
- [x] I did NOT write directly to `*.state.position`, `*.state.velocity`, `*.state.angle`, `*.state.turnSpeed`, or `*.state.health` outside `syncShipProperties` or `space-manager.ts`.

`@gameField` decorator order:
- [x] No new `@gameField` decorators added.

Remote command surface:
- [x] No new commands or state fields added.

Public API:
- [x] I did NOT add new exports to `modules/core/src/index.public.ts`.

Local verification:
- [x] `npm run test:types && npm run test:format && npm run build && npm test` — all pass (37 suites, 347 tests + 2 skipped, 0 failures).
- [x] `npx jest --selectProjects server` — 7 suites, 29 tests, 0 failures, no force-exit warning.

Skill / docs hygiene:
- [x] No skill/doc changes needed.
- [x] No new top-level singletons, unbounded caches, or globally mutable module state were introduced.

## Hotspot files touched

- `modules/server/src/server.ts` — conditional no-op `logger` option added to `new Server({...})`

## Tests added

`modules/server/src/test/colyseus-logging.spec.ts` (1 test):
- `does not call console when Colyseus logger fires under JEST_WORKER_ID` — verifies the no-op logger is active after server creation in test environments.

🤖 Automated by Claude Code
https://claude.ai/code/session_018gYEn7nqjhiXUZxC7tpe5k

---
_Generated by [Claude Code](https://claude.ai/code/session_018gYEn7nqjhiXUZxC7tpe5k)_