### PR TITLE
test: cover all explosion angles and ship rotations in damage test (closes #842)

### DIFF
--- a/modules/core/test/ship-manager.spec.ts
+++ b/modules/core/test/ship-manager.spec.ts
@@ -14,6 +14,7 @@ import {
     makeShipState,
     padArch,
     shipConfigurations,
+    toPositiveDegreesDelta,
 } from '../src';
 import { MockDie, makeIterationsData } from './ship-test-harness';
 import { degree, float } from './properties';
@@ -30,11 +31,13 @@ describe.each([ShipManagerPc, ShipManagerNpc])('%p', (shipManagerCtor) => {
         fc.assert(
             fc.property(
                 degree(),
+                degree(),
                 fc.integer({ min: 15, max: 20 }),
-                (explosionAngleToShip: number, numIterationsPerSecond: number) => {
+                (explosionAngleToShip: number, shipAngle: number, numIterationsPerSecond: number) => {
                     const spaceMgr = new SpaceManager();
                     const shipObj = new Spaceship();
                     shipObj.id = '1';
+                    shipObj.angle = shipAngle;
                     const die = new MockDie();
                     const shipMgr = new shipManagerCtor(
                         shipObj,
@@ -66,8 +69,10 @@ describe.each([ShipManagerPc, ShipManagerNpc])('%p', (shipManagerCtor) => {
                         shipMgr.update(id);
                         spaceMgr.update(id);
                     }
+                    // damage arc is expressed in ship-local frame; account for ship's world rotation
+                    const explosionLocalAngle = toPositiveDegreesDelta(explosionAngleToShip - shipAngle);
                     const expectedHitPlatesRange = padArch(
-                        [explosionAngleToShip, explosionAngleToShip],
+                        [explosionLocalAngle, explosionLocalAngle],
                         sizeOfPlate + EPSILON,
                     );
                     //@ts-ignore : access private property


### PR DESCRIPTION
Closes #842

## Summary

- Extends the `'explosion must damage only affected areas'` property-based test to vary the ship's own rotation angle (`shipAngle`) as a second `degree()` parameter.
- Expected hit-plate range is now computed in the ship's **local frame**: `explosionLocalAngle = toPositiveDegreesDelta(explosionAngleToShip - shipAngle)`, verifying that `globalToLocal` correctly maps world-space collision points to armor plates for any ship orientation.
- Previously the test only covered ship angle = 0 (world frame = local frame); now it covers all 360° × 360° combinations of explosion direction and ship rotation.

## Tests

`modules/core/test/ship-manager.spec.ts` — added `shipAngle` property parameter and local-frame expected-range computation to the existing explosion damage test.

🤖 Automated by Claude Code
https://claude.ai/code/session_01Gy9PbJ4aL4co99T2oTHrQ1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gy9PbJ4aL4co99T2oTHrQ1)_