### PR TITLE
test: silence app-logger noise under Jest, keep DEBUG escape hatch

### DIFF
--- a/.claude/skills/starwards-debugging/SKILL.md
+++ b/.claude/skills/starwards-debugging/SKILL.md
@@ -59,6 +59,11 @@ npm test
 # Read expected vs actual values
 # Check if float precision issue (use toBeCloseTo)
 # Verify async operations completed (await harness.waitForSync())
+
+# App logs (logInfo/logWarn/logError) are silenced under Jest by default.
+# Surface them for the run when tracing a failure:
+DEBUG=starwards:* npm test                 # all namespaces
+DEBUG=starwards:space-manager:* npm test   # one subsystem
 ```
 
 **Playwright failures:**

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -360,6 +360,17 @@ npm run test:e2e -- --headed  # Visible browser
 npm run test:e2e -- --debug   # Inspector
 ```
 
+### Seeing application logs during tests
+
+App logs (`logInfo/logWarn/logError`) are silenced under Jest by default to keep output clean. Turn them back on for a run with the `DEBUG` env var:
+
+```bash
+DEBUG=starwards:* npm test                    # all namespaces
+DEBUG=starwards:space-manager:* npm test      # one subsystem
+```
+
+Outside Jest (dev/prod) these channels are always on, so this only affects test runs. See `modules/core/src/logger.ts`.
+
 ## Best Practices
 
 ### Unit Tests
@@ -408,7 +419,6 @@ npm run test:e2e -- --debug   # Inspector
 ### Known CI flakiness (pre-existing, not a regression)
 
 - **Green e2e jobs can hide first-attempt failures.** `playwright.config.ts` sets `retries: 1` on CI, so a test that fails once and passes on retry is reported "flaky" and the job stays green. Check the "flaky" count in the run summary, not just the job conclusion.
-- **`Error: Cannot find module '@starwards/server'`** — a handful of driver-based specs (pilot/weapons/signals screens + hotkeys) intermittently fail at import on first attempt with this error and pass on retry. Verified present on master before PR #1938 (same 5 flaky specs in master and PR runs). Symptom points at a Playwright worker-startup race resolving the workspace package through tsconfig `paths` (`require-in-the-middle` appears in the stack). Suspected fix, untried: give `modules/server/package.json` a `main`/`exports` entry pointing at `cjs/` so Node resolution has a fallback when the transform race loses.
 
 **See:** [UTILITIES.md](UTILITIES.md) for detailed test utilities reference
 

--- a/modules/core/src/logger.ts
+++ b/modules/core/src/logger.ts
@@ -15,10 +15,14 @@ export function createLogger(namespace: string) {
     // eslint-disable-next-line no-console
     error.log = console.error.bind(console);
 
-    // info, warn, and error are always visible regardless of DEBUG env var
-    info.enabled = true;
-    warn.enabled = true;
-    error.enabled = true;
+    // Force info/warn/error visible in normal runs; under Jest fall back to the
+    // debug package's DEBUG-driven enablement so tests are quiet by default.
+    // Re-enable in a specific test run with DEBUG=starwards:* (or a narrower namespace).
+    if (!process.env.JEST_WORKER_ID) {
+        info.enabled = true;
+        warn.enabled = true;
+        error.enabled = true;
+    }
 
     return { debug, info, warn, error };
 }

--- a/modules/core/src/logger.ts
+++ b/modules/core/src/logger.ts
@@ -18,7 +18,8 @@ export function createLogger(namespace: string) {
     // Force info/warn/error visible in normal runs; under Jest fall back to the
     // debug package's DEBUG-driven enablement so tests are quiet by default.
     // Re-enable in a specific test run with DEBUG=starwards:* (or a narrower namespace).
-    if (!process.env.JEST_WORKER_ID) {
+    // `process` is undefined in the browser bundle (no polyfill), so guard for that too.
+    if (typeof process === 'undefined' || !process.env.JEST_WORKER_ID) {
         info.enabled = true;
         warn.enabled = true;
         error.enabled = true;


### PR DESCRIPTION
## What

Unit tests passed but the console was very noisy. The noise came from **application code under test**, not the tests — `modules/core/src/logger.ts` hard-forced the info/warn/error channels to `enabled = true`, so every `logInfo/logWarn/logError` printed on every run, ignoring `DEBUG`.

## Change

- **`modules/core/src/logger.ts`** — only force-enable info/warn/error when **not** under Jest (`process.env.JEST_WORKER_ID`). Tests are quiet by default; dev/prod logging is unchanged; re-enable in a run with `DEBUG=starwards:*` (or a narrower namespace).
- **`docs/testing/README.md`** — document the escape hatch under "Debugging Tests"; remove the now-stale e2e module-resolution flakiness note (already fixed — `modules/server/package.json` has `main: "cjs/index.js"`).
- **`.claude/skills/starwards-debugging/SKILL.md`** — note the `DEBUG=starwards:*` invocation in the Jest-failure section.

## Verification (probe injected into a spec, then reverted)

| Condition | Logger output under Jest |
|---|---|
| Original logger | prints `starwards:probe:info …` (the noise) |
| Fixed logger | silenced |
| Fixed + `DEBUG=starwards:*` | prints again (escape hatch works) |
| Raw `console.log` | still surfaces — genuine diagnostics not hidden |

Full suite green: `36 suites, 346 passed, 2 skipped`. No `--silent` flag, no new setup files.

## Follow-ups (filed separately)

Other test improvements surfaced during this work: #1946 (leaking server worker handle), #1947 (Jest transform speed), #1948 (Colyseus lifecycle logging in server specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)