### PR TITLE
fix(server): eliminate force-exit warning in Jest worker processes (closes #1946)

### DIFF
--- a/modules/server/src/clean-local-presence.ts
+++ b/modules/server/src/clean-local-presence.ts
@@ -1,0 +1,21 @@
+import { LocalPresence } from '@colyseus/core';
+
+/**
+ * LocalPresence subclass that properly clears pending setTimeout handles on shutdown.
+ *
+ * LocalPresence.expire() and .hincrbyex() schedule setTimeout calls stored in
+ * the internal `timeouts` map. The upstream shutdown() method does not clear
+ * these handles, which keeps Jest worker processes alive after tests complete.
+ */
+export class CleanLocalPresence extends LocalPresence {
+    shutdown() {
+        // Cast to access the private `timeouts` field declared in LocalPresence.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+        const timeouts: Record<string, ReturnType<typeof setTimeout>> = (this as any).timeouts;
+        for (const key of Object.keys(timeouts)) {
+            clearTimeout(timeouts[key]);
+            delete timeouts[key];
+        }
+        super.shutdown();
+    }
+}

--- a/modules/server/src/server.ts
+++ b/modules/server/src/server.ts
@@ -26,15 +26,23 @@ const mapsMap = new Map(Object.values(maps).map((m) => [m.name, m]));
 
 export const HTTP_CONFLICT_STATUS = 409;
 const HTTP_BAD_REQUEST_STATUS = 400;
-export async function server(port: number, staticDirs: string | string[], manager: GameManager) {
+export async function server(
+    port: number,
+    staticDirs: string | string[],
+    manager: GameManager,
+    // Test-only escape hatch: test/driver.ts passes { pingInterval: 0 } to prevent a
+    // 3 s setInterval from outliving gracefullyShutdown() in Jest teardown.
+    // WebSocketTransport.shutdown() calls httpServer.close() without awaiting the
+    // resulting "close" event, so clearInterval(pingInterval) never fires in time.
+    // Production/dev omit this so Colyseus's normal ping heartbeat (dead-connection
+    // detection) stays active.
+    wsTransportOverrides?: { pingInterval?: number; pingMaxRetries?: number },
+) {
     const app = express();
     app.use(express.json() as express.RequestHandler);
     const httpServer = http.createServer(app);
     const gameServer = new Server({
-        // pingInterval: 0 prevents a 3 s setInterval from outliving gracefullyShutdown().
-        // WebSocketTransport.shutdown() calls httpServer.close() without awaiting the
-        // resulting "close" event, so clearInterval(pingInterval) never fires in time.
-        transport: new WebSocketTransport({ server: httpServer, pingInterval: 0 }),
+        transport: new WebSocketTransport({ server: httpServer, ...wsTransportOverrides }),
         greet: false,
         presence: new CleanLocalPresence(),
     });

--- a/modules/server/src/server.ts
+++ b/modules/server/src/server.ts
@@ -1,5 +1,6 @@
 import * as http from 'http';
 import * as maps from './maps';
+import * as path from 'path';
 
 import { NextFunction, Request, Response } from 'express';
 import { Server, matchMaker } from '@colyseus/core';
@@ -7,6 +8,7 @@ import { schemaToString, stringToSchema } from './serialization/game-state-seria
 
 import { AddressInfo } from 'node:net';
 import { AdminRoom } from './admin/room';
+import { CleanLocalPresence } from './clean-local-presence';
 import { GameManager } from './admin/game-manager';
 import { SavedGame } from './serialization/game-state-protocol';
 import { ShipRoom } from './ship/room';
@@ -28,7 +30,14 @@ export async function server(port: number, staticDirs: string | string[], manage
     const app = express();
     app.use(express.json() as express.RequestHandler);
     const httpServer = http.createServer(app);
-    const gameServer = new Server({ transport: new WebSocketTransport({ server: httpServer }), greet: false });
+    const gameServer = new Server({
+        // pingInterval: 0 prevents a 3 s setInterval from outliving gracefullyShutdown().
+        // WebSocketTransport.shutdown() calls httpServer.close() without awaiting the
+        // resulting "close" event, so clearInterval(pingInterval) never fires in time.
+        transport: new WebSocketTransport({ server: httpServer, pingInterval: 0 }),
+        greet: false,
+        presence: new CleanLocalPresence(),
+    });
 
     gameServer.define('space', SpaceRoom);
     gameServer.define('admin', AdminRoom);
@@ -128,6 +137,20 @@ export async function server(port: number, staticDirs: string | string[], manage
     return {
         httpServer,
         addressInfo,
-        close: async () => await gameServer.gracefullyShutdown(false),
+        close: async () => {
+            // Stats.persist() schedules a 1 s setTimeout when createRoom() runs shortly
+            // after the previous persist.  That handle outlives gracefullyShutdown() and
+            // keeps Jest worker processes alive.  Calling reset(true) here clears the
+            // pending timeout and force-flushes the counters before state becomes
+            // SHUTTING_DOWN (at which point Stats.persist() becomes a no-op).
+            // @colyseus/core/package.json restricts sub-path exports, so we resolve
+            // Stats.js via the package entry-point directory rather than a named export.
+
+            const statsPath = path.join(path.dirname(require.resolve('@colyseus/core')), 'Stats.js');
+            // eslint-disable-next-line @typescript-eslint/no-require-imports
+            const Stats = require(statsPath) as { reset: (persist?: boolean) => void };
+            Stats.reset(true);
+            await gameServer.gracefullyShutdown(false);
+        },
     };
 }

--- a/modules/server/src/test/clean-local-presence.spec.ts
+++ b/modules/server/src/test/clean-local-presence.spec.ts
@@ -1,0 +1,35 @@
+import { CleanLocalPresence } from '../clean-local-presence';
+
+describe('CleanLocalPresence', () => {
+    it('shutdown clears all pending expire timeouts', () => {
+        const presence = new CleanLocalPresence();
+        presence.expire('key1', 60);
+        presence.expire('key2', 60);
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+        expect(Object.keys((presence as any).timeouts)).toHaveLength(2);
+
+        presence.shutdown();
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+        expect(Object.keys((presence as any).timeouts)).toHaveLength(0);
+    });
+
+    it('shutdown clears pending hincrbyex timeouts', async () => {
+        const presence = new CleanLocalPresence();
+        await presence.hincrbyex('key1', 'field', 1, 60);
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+        expect(Object.keys((presence as any).timeouts)).toHaveLength(1);
+
+        presence.shutdown();
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+        expect(Object.keys((presence as any).timeouts)).toHaveLength(0);
+    });
+
+    it('shutdown tolerates an empty timeout map', () => {
+        const presence = new CleanLocalPresence();
+        expect(() => presence.shutdown()).not.toThrow();
+    });
+});

--- a/modules/server/src/test/driver.ts
+++ b/modules/server/src/test/driver.ts
@@ -49,7 +49,11 @@ export function makeDriver() {
 
     beforeEach(async () => {
         gameManager = new GameManager();
-        serverInfo = await server(0, path.resolve(__dirname, '..', '..', '..', 'static'), gameManager);
+        // pingInterval: 0 avoids a lingering setInterval outliving gracefullyShutdown()
+        // during Jest teardown; see server.ts for why this is test-only.
+        serverInfo = await server(0, path.resolve(__dirname, '..', '..', '..', 'static'), gameManager, {
+            pingInterval: 0,
+        });
         sockets = makeSocketsControls(serverInfo.httpServer);
     });
 


### PR DESCRIPTION
## Summary

- Introduces `CleanLocalPresence`, a `LocalPresence` subclass that drains the private `timeouts` map on `shutdown()` — upstream `LocalPresence.expire()` and `.hincrbyex()` store `setTimeout` handles there without ever clearing them.
- Passes `pingInterval: 0` to `WebSocketTransport` so no 3 s ping `setInterval` is created; `WebSocketTransport.shutdown()` calls `httpServer.close()` without awaiting its `"close"` event, so `clearInterval(pingInterval)` would never fire in time otherwise.
- In `server.ts` `close()`, calls `Stats.reset(true)` before `gracefullyShutdown()` to clear `Stats.persistTimeout` — a 1 s `setTimeout` that `Stats.persist()` schedules whenever `createRoom()` runs within 1 s of the previous persist, which is always true in tests; while the callback is a no-op during shutdown, the handle keeps Jest worker processes alive.

No `forceExit: true` shortcut, no Jest config changes.

## Tests

- `modules/server/src/test/clean-local-presence.spec.ts` — three unit tests covering the `CleanLocalPresence.shutdown()` contract: clears `expire` timeouts, clears `hincrbyex` timeouts, and tolerates an empty map.

🤖 Automated by Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_019TEviZuXrRtGNJp7u6Yy8d)_