### PR TITLE
feat: client-side waypoint layer visibility store (closes #1214)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -43,5 +43,10 @@ module.exports = {
             displayName: 'node-red',
             testRegex: 'modules/node-red/.*\\.spec\\.ts$',
         },
+        {
+            ...baseConfig,
+            displayName: 'browser',
+            testRegex: 'modules/browser/.*\\.spec\\.ts$',
+        },
     ],
 };

--- a/modules/browser/src/radar/waypoint-layer-visibility.ts
+++ b/modules/browser/src/radar/waypoint-layer-visibility.ts
@@ -1,0 +1,55 @@
+import { SpaceObject, Waypoint } from '@starwards/core';
+
+import { Callback } from '../property-wrappers';
+
+interface SpaceState {
+    [Symbol.iterator](): Iterator<SpaceObject>;
+}
+
+export class WaypointLayerVisibility {
+    private visible = new Map<string, boolean>();
+    private callbacks: Callback[] = [];
+
+    isVisible(collection: string): boolean {
+        return this.visible.get(collection) ?? true;
+    }
+
+    setVisible(collection: string, visible: boolean): void {
+        const prev = this.isVisible(collection);
+        this.visible.set(collection, visible);
+        if (prev !== visible) {
+            this.notify();
+        }
+    }
+
+    toggle(collection: string): void {
+        this.setVisible(collection, !this.isVisible(collection));
+    }
+
+    update(state: SpaceState): void {
+        let changed = false;
+        for (const obj of state) {
+            if (Waypoint.isInstance(obj) && !this.visible.has(obj.collection)) {
+                this.visible.set(obj.collection, true);
+                changed = true;
+            }
+        }
+        if (changed) {
+            this.notify();
+        }
+    }
+
+    onChange(cb: Callback): () => void {
+        this.callbacks.push(cb);
+        return () => {
+            const idx = this.callbacks.indexOf(cb);
+            if (idx !== -1) this.callbacks.splice(idx, 1);
+        };
+    }
+
+    private notify(): void {
+        for (const cb of this.callbacks) {
+            cb();
+        }
+    }
+}

--- a/modules/browser/src/widgets/pilot-radar.ts
+++ b/modules/browser/src/widgets/pilot-radar.ts
@@ -13,6 +13,7 @@ import { MovementAnchorLayer } from '../radar/movement-anchor-layer';
 import { ObjectsLayer } from '../radar/blips/objects-layer';
 import { RadarRangeFilter } from '../radar/blips/radar-range-filter';
 import { RangeIndicators } from '../radar/range-indicators';
+import { WaypointLayerVisibility } from '../radar/waypoint-layer-visibility';
 import WebFont from 'webfontloader';
 import { WidgetContainer } from '../container';
 
@@ -65,12 +66,14 @@ export async function drawPilotRadar(spaceDriver: SpaceDriver, shipDriver: ShipD
     contentElements.mask = contentMask;
 
     const rangeFilter = new RadarRangeFilter(spaceDriver, (o: SpaceObject) => o.faction === shipDriver.state.faction);
+    const waypointVisibility = new WaypointLayerVisibility();
     const fovGraphics = new Graphics();
     contentElements.addChild(fovGraphics);
 
     root.ticker.add(
         () => {
             rangeFilter.update();
+            waypointVisibility.update(spaceDriver.state);
             fovGraphics.clear();
             for (const fov of rangeFilter.fieldsOfView()) {
                 fov.draw(root, fovGraphics);
@@ -119,7 +122,7 @@ export async function drawPilotRadar(spaceDriver: SpaceDriver, shipDriver: ShipD
         (w) => w.color,
         tacticalDrawWaypoints,
         undefined,
-        (w) => XY.lengthOf(XY.difference(w.position, camera)) <= p.range,
+        (w) => waypointVisibility.isVisible(w.collection) && XY.lengthOf(XY.difference(w.position, camera)) <= p.range,
     );
     contentElements.addChild(waypointsInRange.renderRoot);
 

--- a/modules/browser/test/waypoint-layer-visibility.spec.ts
+++ b/modules/browser/test/waypoint-layer-visibility.spec.ts
@@ -1,0 +1,106 @@
+import { Waypoint } from '@starwards/core';
+import { WaypointLayerVisibility } from '../src/radar/waypoint-layer-visibility';
+
+function makeWaypoint(collection: string, id = 'w1'): Waypoint {
+    const w = new Waypoint();
+    w.id = id;
+    w.collection = collection;
+    return w;
+}
+
+function makeSpaceState(waypoints: Waypoint[]) {
+    return {
+        *[Symbol.iterator]() {
+            yield* waypoints;
+        },
+    };
+}
+
+describe('WaypointLayerVisibility', () => {
+    test('unknown collections default to visible', () => {
+        const store = new WaypointLayerVisibility();
+        expect(store.isVisible('mission')).toBe(true);
+        expect(store.isVisible('')).toBe(true);
+    });
+
+    test('setVisible hides a collection', () => {
+        const store = new WaypointLayerVisibility();
+        store.setVisible('mission', false);
+        expect(store.isVisible('mission')).toBe(false);
+    });
+
+    test('setVisible makes a collection visible again', () => {
+        const store = new WaypointLayerVisibility();
+        store.setVisible('mission', false);
+        store.setVisible('mission', true);
+        expect(store.isVisible('mission')).toBe(true);
+    });
+
+    test('toggle flips visibility', () => {
+        const store = new WaypointLayerVisibility();
+        store.toggle('mission');
+        expect(store.isVisible('mission')).toBe(false);
+        store.toggle('mission');
+        expect(store.isVisible('mission')).toBe(true);
+    });
+
+    test('update discovers collections from space state', () => {
+        const store = new WaypointLayerVisibility();
+        const waypoints = [makeWaypoint('alpha', 'w1'), makeWaypoint('beta', 'w2')];
+        store.update(makeSpaceState(waypoints));
+        expect(store.isVisible('alpha')).toBe(true);
+        expect(store.isVisible('beta')).toBe(true);
+    });
+
+    test('onChange fires when setVisible changes value', () => {
+        const store = new WaypointLayerVisibility();
+        const calls: boolean[] = [];
+        store.onChange(() => calls.push(true));
+        store.setVisible('mission', false);
+        expect(calls.length).toBe(1);
+    });
+
+    test('onChange does not fire when value is unchanged', () => {
+        const store = new WaypointLayerVisibility();
+        const calls: boolean[] = [];
+        store.onChange(() => calls.push(true));
+        store.setVisible('mission', true); // already true (default)
+        expect(calls.length).toBe(0);
+    });
+
+    test('onChange fires when update discovers a new collection', () => {
+        const store = new WaypointLayerVisibility();
+        const calls: boolean[] = [];
+        store.onChange(() => calls.push(true));
+        store.update(makeSpaceState([makeWaypoint('new-collection')]));
+        expect(calls.length).toBe(1);
+    });
+
+    test('onChange does not fire when update finds no new collections', () => {
+        const store = new WaypointLayerVisibility();
+        const waypoints = [makeWaypoint('alpha')];
+        store.update(makeSpaceState(waypoints));
+        const calls: boolean[] = [];
+        store.onChange(() => calls.push(true));
+        store.update(makeSpaceState(waypoints)); // same collection
+        expect(calls.length).toBe(0);
+    });
+
+    test('onChange cleanup unsubscribes', () => {
+        const store = new WaypointLayerVisibility();
+        const calls: boolean[] = [];
+        const cleanup = store.onChange(() => calls.push(true));
+        cleanup();
+        store.setVisible('mission', false);
+        expect(calls.length).toBe(0);
+    });
+
+    test('visibility filter returns false for hidden collection waypoints', () => {
+        const store = new WaypointLayerVisibility();
+        store.setVisible('secret', false);
+        const w = makeWaypoint('secret');
+        expect(store.isVisible(w.collection)).toBe(false);
+        const w2 = makeWaypoint('public');
+        expect(store.isVisible(w2.collection)).toBe(true);
+    });
+});


### PR DESCRIPTION
Closes #1214

## Summary

- New `WaypointLayerVisibility` (`modules/browser/src/radar/waypoint-layer-visibility.ts`) — a client-side, non-synced store tracking which waypoint `collection` values ("layers") are visible.
  - `isVisible(collection): boolean` — unknown/new collections default to `true`
  - `setVisible(collection, visible)`
  - `toggle(collection)`
  - `update(spaceState)` — discovers collections from `Waypoint` objects currently in space state; newly-discovered collections default to visible
  - `onChange(cb): () => void` — subscribe/unsubscribe for change notifications, following the callback-array pattern used by `propertyStub` in `modules/browser/src/property-wrappers.ts`
- Wired into `modules/browser/src/widgets/pilot-radar.ts`: the `waypointsInRange` `ObjectsLayer` filter now also checks `waypointVisibility.isVisible(w.collection)`; the store's `update()` runs once per tick alongside the existing range filter. With all collections at their default (visible), rendering is unchanged.

## MUST fill in

State sync invariants:
- [x] No writes to `*.state.position/velocity/angle/turnSpeed/health` outside `syncShipProperties`/`space-manager.ts`. This store is purely client-side and never touches synced state.

`@gameField` decorator order:
- [x] No new `@gameField` decorators added.

Remote command surface:
- [x] No new commands or state fields added — this is a browser-only, non-synced store.

Public API:
- [x] No new exports added to `modules/core/src/index.public.ts`.

Local verification:
- [x] `npm run test:types && npm run test:format && npm run build && npm test` — all pass (38 suites, 360 tests + 2 skipped, 0 failures).

Skill / docs hygiene:
- [x] No skill/doc changes needed for this scope.
- [x] No new top-level singletons/unbounded caches/global mutable state — the store is instantiated per radar/screen instance (see `pilot-radar.ts`).

## Hotspot files touched

- `jest.config.js` — added a `browser` Jest project (`modules/browser/.*\.spec\.ts$`) since no browser unit tests existed before.
- `modules/browser/src/widgets/pilot-radar.ts` — instantiate `WaypointLayerVisibility`, call `update()` per tick, filter `waypointsInRange` by it.

## Tests added

`modules/browser/test/waypoint-layer-visibility.spec.ts` (11 tests): default visibility, `setVisible`/`toggle`, collection discovery via `update()`, `onChange` firing/not-firing semantics, and unsubscribe cleanup.

## Out of scope (per issue)

UI widget for toggling layers (#1210) and relay radar integration (#1209) are separate issues; this PR is the model/store piece only.

🤖 Automated by Claude Code
https://claude.ai/code/session_01Hwz4Yc5funLqafJH5QqMv3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hwz4Yc5funLqafJH5QqMv3)_