### PR TITLE
perf: mark frozen collision bodies as static (closes #863)

### DIFF
--- a/modules/core/src/logic/space-manager.ts
+++ b/modules/core/src/logic/space-manager.ts
@@ -431,6 +431,10 @@ export class SpaceManager implements Updateable {
             if (object.freeze || this.attachments.get(object.id)) {
                 object.velocity.x = object.velocity.y = object.turnSpeed = 0;
             }
+            const data = this.stateToExtraData.get(object);
+            if (data) {
+                data.body.isStatic = object.freeze;
+            }
         }
     }
 

--- a/modules/core/test/space-manager.spec.ts
+++ b/modules/core/test/space-manager.spec.ts
@@ -19,6 +19,7 @@ import {
     concatinateArchs,
 } from '../src';
 
+import { Circle } from 'detect-collisions';
 import { SpaceSimulator } from './simulator';
 import { expect } from 'chai';
 import fc from 'fast-check';
@@ -498,6 +499,48 @@ describe('SpaceManager', () => {
         const found = [...spaceMgr.state.getAll('Spaceship')].find((s) => s.id === 'pos-test');
         expect(found!.position.x).to.equal(100);
         expect(found!.position.y).to.equal(200);
+    });
+
+    describe('collision body isStatic optimization', () => {
+        function getCollisionBody(spaceMgr: SpaceManager, object: SpaceObject) {
+            const bodies = spaceMgr.collisions.all() as Circle[];
+            return bodies.find(
+                (body) => body.x === object.position.x && body.y === object.position.y && body.r === object.radius,
+            );
+        }
+
+        it('marks a frozen object collision body as static, and unmarks it when unfrozen', () => {
+            const spaceMgr = new SpaceManager();
+            const asteroid = new Asteroid();
+            asteroid.id = 'static-test-asteroid';
+            asteroid.position = Vec2.make({ x: 1234, y: 4321 });
+            spaceMgr.insert(asteroid);
+            spaceMgr.forceFlushEntities();
+
+            spaceMgr.update({ deltaSeconds: 0.1, deltaSecondsAvg: 0.1, totalSeconds: 0.1 });
+            expect(getCollisionBody(spaceMgr, asteroid)?.isStatic).to.equal(false);
+
+            asteroid.freeze = true;
+            spaceMgr.update({ deltaSeconds: 0.1, deltaSecondsAvg: 0.1, totalSeconds: 0.1 });
+            expect(getCollisionBody(spaceMgr, asteroid)?.isStatic).to.equal(true);
+
+            asteroid.freeze = false;
+            spaceMgr.update({ deltaSeconds: 0.1, deltaSecondsAvg: 0.1, totalSeconds: 0.1 });
+            expect(getCollisionBody(spaceMgr, asteroid)?.isStatic).to.equal(false);
+        });
+
+        it('removes a destroyed object collision body outright (no need to mark it static)', () => {
+            const spaceMgr = new SpaceManager();
+            const asteroid = new Asteroid();
+            asteroid.id = 'static-test-destroyed';
+            asteroid.position = Vec2.make({ x: 5678, y: 8765 });
+            spaceMgr.insert(asteroid);
+            spaceMgr.forceFlushEntities();
+
+            spaceMgr.destroyObject(asteroid.id);
+            spaceMgr.update({ deltaSeconds: 0.1, deltaSecondsAvg: 0.1, totalSeconds: 0.1 });
+            expect(getCollisionBody(spaceMgr, asteroid)).to.equal(undefined);
+        });
     });
 
     it('insertBulk adds multiple objects', () => {


### PR DESCRIPTION
Closes #863

## Summary

- `SpaceManager.frozendAndAttachedDontMove()` now syncs each object's collision body `isStatic` flag to `object.freeze` every tick. `detect-collisions` (via the `check2d` fork) already skips a static body's own outgoing collision search in `checkAll()`/`checkOne()` while still finding it through other (dynamic) bodies' searches — so frozen objects (which never move, since their velocity is force-zeroed) stop paying search/broad-phase cost each tick, with no change in collision behavior.
- Investigated the "destroyed" half of the issue: destroyed objects' collision bodies are already removed from the collision system on the very next tick via the existing `untrackDestroyedObjects()` call (which runs unconditionally each `update()`, ahead of `handleCollisions()`) — so there's no lingering destroyed body to mark `isStatic`, and no change was needed there. Added a test pinning that existing behavior.

## Tests

- `modules/core/test/space-manager.spec.ts`: new `collision body isStatic optimization` describe block —
  - `marks a frozen object collision body as static, and unmarks it when unfrozen`
  - `removes a destroyed object collision body outright (no need to mark it static)`

Verification run locally: `npm run test:types && npm run test:format && npm run build && npm test` — all pass (37 suites, 351 tests + 2 skipped, 0 failures).

🤖 Automated by Claude Code
https://claude.ai/code/session_01JdWFCsAA2Yjo6mRuHhcpPB


---
_Generated by [Claude Code](https://claude.ai/code/session_01JdWFCsAA2Yjo6mRuHhcpPB)_