### PR TITLE
fix: auto-complete missing protocol on starwards-config URL (closes #1294)

### DIFF
--- a/modules/node-red/src/starwards-config/starwards-config.spec.ts
+++ b/modules/node-red/src/starwards-config/starwards-config.spec.ts
@@ -28,6 +28,13 @@ describe('starwards-config', () => {
         expect(node.driver).toBeInstanceOf(Driver);
     });
 
+    it('auto-completes a missing protocol to http://', async () => {
+        const flows: Flows = [{ id: 'n1', type: 'starwards-config', url: '127.1.2.3:8080' }];
+        await helper.load(initNodes, flows);
+        const { node } = getNode<StarwardsConfigNode>('n1');
+        expect(node.driver.httpEndpoint).toEqual('http://127.1.2.3:8080');
+    });
+
     describe('integration with server', () => {
         const gameDriver = makeDriver();
 

--- a/modules/node-red/src/starwards-config/starwards-config.ts
+++ b/modules/node-red/src/starwards-config/starwards-config.ts
@@ -9,10 +9,18 @@ export interface StarwardsConfigOptions {
 export interface StarwardsConfigNode extends Node {
     driver: Driver;
 }
+
+// users often paste a bare host (e.g. `localhost:8080`) instead of a full URL.
+// `new URL('localhost:8080')` parses that as protocol `localhost:` rather than throwing,
+// so detect a missing scheme and default it to http://.
+export function withDefaultProtocol(url: string): string {
+    return /^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//.test(url) ? url : `http://${url}`;
+}
+
 const nodeInit: NodeInitializer = (RED): void => {
     function StarwardsConfigNodeConstructor(this: StarwardsConfigNode, config: NodeDef & StarwardsConfigOptions): void {
         RED.nodes.createNode(this, config);
-        this.driver = new Driver(new URL(config.url)).connect(1_000);
+        this.driver = new Driver(new URL(withDefaultProtocol(config.url))).connect(1_000);
         this.on('close', () => this.driver.destroy());
     }
 


### PR DESCRIPTION
Closes #1294

## Summary

- `new URL('localhost:8080')` doesn't throw — it silently parses `localhost` as the URL *scheme* (schemes just need to start with a letter), leaving `host` empty and breaking the connection. Previously, a bare host like `127.1.2.3:8080` (starting with a digit) wasn't even a valid scheme, so the config node's constructor threw and node-red silently failed to register the node at all.
- Added `withDefaultProtocol()` in `modules/node-red/src/starwards-config/starwards-config.ts`: if the configured URL string doesn't already start with `scheme://`, it's prefixed with `http://` before being passed to `new URL(...)`.
- This covers both failure modes from the issue: a bare host (`127.1.2.3`) and a bare host with a colon that node-red users might paste from the main menu page (`localhost:8080`).

## Tests

- `modules/node-red/src/starwards-config/starwards-config.spec.ts`: added `auto-completes a missing protocol to http://`, asserting `node.driver.httpEndpoint === 'http://127.1.2.3:8080'` when the configured `url` is `127.1.2.3:8080`. Confirmed RED first — without the fix, the node fails to load at all because `new URL('127.1.2.3:8080')` throws (invalid scheme).

Verification run locally: `npm run test:types && npm run test:format && npm run build && npm test` — all pass (37 suites, 350 tests + 2 skipped, 0 failures).

🤖 Automated by Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01PV7Ws3coZgUgy4MBgY31Sw)_