### PR TITLE
fix: show broken status in damage report widget (closes #1233)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -43,5 +43,10 @@ module.exports = {
             displayName: 'node-red',
             testRegex: 'modules/node-red/.*\\.spec\\.ts$',
         },
+        {
+            ...baseConfig,
+            displayName: 'browser',
+            testRegex: 'modules/browser/.*\\.spec\\.ts$',
+        },
     ],
 };

--- a/modules/browser/src/react/hooks.ts
+++ b/modules/browser/src/react/hooks.ts
@@ -1,4 +1,13 @@
-import { AdminDriver, DefectibleValue, Destructors, Driver, GameStatus, ShipDriver, TaskLoop } from '@starwards/core';
+import {
+    AdminDriver,
+    DefectibleValue,
+    Destructors,
+    Driver,
+    GameStatus,
+    ShipDriver,
+    System,
+    TaskLoop,
+} from '@starwards/core';
 import { DependencyList, useEffect, useRef, useState } from 'react';
 import { abstractOnChange, readProp } from '../property-wrappers';
 
@@ -76,6 +85,37 @@ export function defectReadProp(driver: ShipDriver) {
             },
             getValue: () => {
                 return { name, status: d.name, pointer, alertTime, isOk };
+            },
+        };
+    };
+}
+
+export function brokenReadProp(driver: ShipDriver) {
+    return (system: System) => {
+        const pointerStr = `${system.pointer}/broken`;
+        const brokenProp = readProp<boolean>(driver, pointerStr);
+        let alertTime = 0;
+        let wasBroken = !!brokenProp.getValue();
+        return {
+            pointer: brokenProp.pointer,
+            onChange(cb: () => unknown) {
+                return brokenProp.onChange(() => {
+                    const isBroken = !!brokenProp.getValue();
+                    if (isBroken && !wasBroken) {
+                        alertTime = Date.now();
+                    }
+                    wasBroken = isBroken;
+                    cb();
+                });
+            },
+            getValue: () => {
+                return {
+                    name: system.state.name,
+                    status: 'offline',
+                    pointer: pointerStr,
+                    alertTime,
+                    isOk: !brokenProp.getValue(),
+                };
             },
         };
     };

--- a/modules/browser/src/widgets/damage-report.tsx
+++ b/modules/browser/src/widgets/damage-report.tsx
@@ -1,6 +1,6 @@
 import { ArwesThemeProvider, StylesBaseline, Text } from '../components/arwes-compat';
 import React, { Component, useEffect, useRef } from 'react';
-import { defectReadProp, useProperties } from '../react/hooks';
+import { brokenReadProp, defectReadProp, useProperties } from '../react/hooks';
 
 import { BleepsProvider } from '../components/arwes-compat';
 import { DashboardWidget } from './dashboard';
@@ -68,9 +68,9 @@ function SystemStatusReport({ name, status, isOk }: { name: string; status: stri
 }
 function AllReports({ driver }: { driver: ShipDriver }) {
     const divRef = useRef<null | HTMLDivElement>(null);
-    const defectsState = useProperties(driver.systems.flatMap((s) => s.defectibles).map(defectReadProp(driver))).sort(
-        (a, b) => a.alertTime - b.alertTime,
-    );
+    const defectsState = useProperties(driver.systems.flatMap((s) => s.defectibles).map(defectReadProp(driver)));
+    const brokenState = useProperties(driver.systems.map(brokenReadProp(driver)));
+    const reports = [...defectsState, ...brokenState].sort((a, b) => a.alertTime - b.alertTime);
     return (
         <>
             <>
@@ -79,7 +79,7 @@ function AllReports({ driver }: { driver: ShipDriver }) {
                 </Text>
                 <br />
             </>
-            {defectsState.map((d) => (
+            {reports.map((d) => (
                 <SystemStatusReport key={d.pointer} name={d.name} status={d.status} isOk={d.isOk} />
             ))}
             <div ref={divRef} />

--- a/modules/browser/test/hooks.spec.ts
+++ b/modules/browser/test/hooks.spec.ts
@@ -1,0 +1,56 @@
+import { ShipDriver, System } from '@starwards/core';
+
+import { EventEmitter } from 'events';
+import { brokenReadProp } from '../src/react/hooks';
+
+function makeSystem(pointer: string, name: string): System {
+    return {
+        pointer,
+        state: { name } as System['state'],
+        defectibles: [],
+        getStatus: () => 'OK',
+        getHeatStatus: () => 'OK',
+    };
+}
+
+function makeDriver(initialState: Record<string, unknown>) {
+    const events = new EventEmitter();
+    const driver = {
+        state: initialState,
+        events,
+        sendJsonCmd: jest.fn(),
+        emitChange(pointer: string) {
+            events.emit(pointer);
+        },
+    };
+    return driver as unknown as ShipDriver & { emitChange(pointer: string): void };
+}
+
+describe('brokenReadProp', () => {
+    test('reports isOk true and the system name when the system is not broken', () => {
+        const driver = makeDriver({ reactor: { name: 'Reactor', broken: false } });
+        const system = makeSystem('/reactor', 'Reactor');
+
+        const prop = brokenReadProp(driver)(system);
+
+        expect(prop.getValue()).toMatchObject({ name: 'Reactor', isOk: true });
+    });
+
+    test('flips to isOk false and stamps alertTime when the system breaks', () => {
+        const state = { reactor: { name: 'Reactor', broken: false } };
+        const driver = makeDriver(state);
+        const system = makeSystem('/reactor', 'Reactor');
+
+        const prop = brokenReadProp(driver)(system);
+        const onChange = jest.fn();
+        prop.onChange(onChange);
+
+        state.reactor.broken = true;
+        driver.emitChange('/reactor/broken');
+
+        expect(onChange).toHaveBeenCalledTimes(1);
+        const value = prop.getValue();
+        expect(value.isOk).toBe(false);
+        expect(value.alertTime).toBeGreaterThan(0);
+    });
+});


### PR DESCRIPTION
Closes #1233

## Summary

- The Damage Report widget (`modules/browser/src/widgets/damage-report.tsx`) only reported individual defectible fields drifting from their normal value. A system that is fully offline (`SystemState.broken === true`) with no drifted defectible field wasn't shown as offline.
- Added `brokenReadProp` in `modules/browser/src/react/hooks.ts`, mirroring the existing `defectReadProp` pattern: it reads the system's `broken` flag through the JSON-pointer surface, using the synthetic `${systemPointer}/broken` change event that `ShipDriver` already emits whenever any defectible on that system changes (`modules/core/src/client/ship.ts`).
- `AllReports` in `damage-report.tsx` now merges per-defectible reports with one broken-status report per system, so a broken system shows an "offline" entry even when no single defectible field is individually flagged.

## Tests

`modules/browser/test/hooks.spec.ts` (new, TDD):
- reports `isOk: true` when a system is not broken
- flips to `isOk: false` and stamps `alertTime` when the system's `broken` flag flips, firing the `onChange` callback

Confirmed RED first: the test failed with `brokenReadProp is not a function` before the implementation was added.

Note: no browser unit test project existed before this change (`modules/browser`'s own `test` script was a no-op); added a `browser` project to the root `jest.config.js` so this test actually runs under `npm test`.

## Verification

- `npm run test:types` — clean
- `npm run test:format` — clean
- `npm run build` — all modules build
- `npm test` — 38 suites, 351 passed + 2 skipped, 0 failures

E2E (`npm run test:e2e`) could not be run locally in this sandbox — the pre-installed Playwright browser revision (1194) doesn't match the revision this repo's `@playwright/test` version expects (1228), a pre-existing environment mismatch unrelated to this change. No existing e2e spec exercises the damage report widget (it's a golden-layout dashboard widget, not opened by default), so this change has no e2e coverage either way; relying on CI to confirm no regressions elsewhere.

🤖 Automated by Claude Code
https://claude.ai/code/session_01GFYV2BENh35fyHawDfZaGF

---
_Generated by [Claude Code](https://claude.ai/code/session_01GFYV2BENh35fyHawDfZaGF)_