### PR TITLE
feat: versioned downloadable releases — GitHub Release binaries + lobby version (closes #1295)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+    push:
+        tags:
+            - 'v*'
+
+jobs:
+    Release:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        steps:
+            - uses: actions/checkout@v4
+            - name: Set up Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version-file: '.nvmrc'
+                  cache: 'npm'
+            - run: npm ci
+            - run: npm run build
+            - run: npm run pkg
+            - name: Create GitHub Release with executable
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const fs = require('fs');
+                      const path = require('path');
+                      const tag = context.ref.replace('refs/tags/', '');
+                      const { data: release } = await github.rest.repos.createRelease({
+                          ...context.repo,
+                          tag_name: tag,
+                          name: tag,
+                          generate_release_notes: true,
+                      });
+                      await github.rest.repos.uploadReleaseAsset({
+                          ...context.repo,
+                          release_id: release.id,
+                          name: 'starwards.exe',
+                          data: fs.readFileSync(path.join(process.env.GITHUB_WORKSPACE, 'dist', 'exec', 'starwards.exe')),
+                      });

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Starwards emerged from years of extending EmptyEpsilon for space LARPs (2016-202
 
 Starwards is a space and starship simulator designed specifically for LARPs (Live Action Role-Playing games). Derived from the "Starship Bridge Simulator" genre, Starwards is designed to support long games where the players interact with the ship's system throughout the ship, not just in the bridge.
 
-# how to run and use it
+# Download & run
 
-Executables are built by CI on every change to master.
-Open the [CI workflow runs](https://github.com/starwards/starwards/actions/workflows/ci-cd.yml?query=branch%3Amaster), click the top-most run, scroll to the "Artifacts" section, and download the "Windows executable" (requires being signed in to GitHub).
-Run it, and open [this link](http://localhost/) in your browser.
+1. Go to the [Releases page](https://github.com/starwards/starwards/releases) and download `starwards.exe` from the latest release (Windows only).
+2. Run `starwards.exe` - it starts the game server on port 8080.
+3. Open [http://localhost:8080](http://localhost:8080) in your browser.
 
-This is not a solution we like. We are [open to improvements and suggestions](https://github.com/starwards/starwards/issues/832).
+If you'd rather build from source, or want a version that hasn't been released yet, see [developing](#developing) below - `npm run build && npm run pkg` produces the same executable at `dist/exec/starwards.exe`. Executables are also built by CI on every change to master: open the [CI workflow runs](https://github.com/starwards/starwards/actions/workflows/ci-cd.yml?query=branch%3Amaster), click the top-most run, and download the "Windows executable" artifact (requires being signed in to GitHub).
 
 # developing
 

--- a/modules/browser/src/components/lobby.tsx
+++ b/modules/browser/src/components/lobby.tsx
@@ -1,10 +1,10 @@
 import { ArwesThemeProvider, Button, Card, StylesBaseline, Text } from './arwes-compat';
+import { Driver, VERSION } from '@starwards/core';
 import { LoadGame, useSaveGameHandler } from './save-load-game';
 import { useAdminDriver, useCanStartGame, useIsGameRunning, usePlayerShips } from '../react/hooks';
 
 import { AnimatorGeneralProvider } from './arwes-compat';
 import { BleepsProvider } from './arwes-compat';
-import { Driver } from '@starwards/core';
 import React from 'react';
 import WebFont from 'webfontloader';
 
@@ -185,6 +185,12 @@ export const Lobby = (p: Props) => {
                                 Colyseus Monitor
                             </Button>
                         </pre>
+                    </div>
+                    <div
+                        data-id="version"
+                        style={{ position: 'fixed', bottom: 4, right: 8, fontSize: 12, opacity: 0.6 }}
+                    >
+                        v{VERSION}
                     </div>
                 </AnimatorGeneralProvider>
             </BleepsProvider>

--- a/modules/core/src/index.public.ts
+++ b/modules/core/src/index.public.ts
@@ -93,5 +93,8 @@ export type { Destructor } from './utils';
 // --- logger ---
 export { createLogger } from './logger';
 
+// --- version ---
+export { VERSION } from './version';
+
 // --- space-object-base (re-exported via ./space) ---
 export { TypeFilter, filterObject } from './space';

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -37,3 +37,4 @@ export * from './tweakable';
 export * from './updateable';
 export * from './utils';
 export * from './logger';
+export * from './version';

--- a/modules/core/src/version.ts
+++ b/modules/core/src/version.ts
@@ -1,0 +1,3 @@
+import corePackageJson from '../package.json';
+
+export const VERSION = corePackageJson.version;

--- a/modules/core/test/version.spec.ts
+++ b/modules/core/test/version.spec.ts
@@ -1,0 +1,9 @@
+import { VERSION } from '../src/version';
+
+import corePackageJson from '../package.json';
+
+describe('VERSION', () => {
+    test('matches the version in package.json', () => {
+        expect(VERSION).toEqual(corePackageJson.version);
+    });
+});

--- a/modules/e2e/test/integration.spec.ts
+++ b/modules/e2e/test/integration.spec.ts
@@ -1,8 +1,15 @@
 import { expect, test } from '@playwright/test';
 
+import { VERSION } from '@starwards/core';
+
 import { makeDriver } from './driver';
 
 const gameDriver = makeDriver(test);
+
+test('lobby shows the running game version', async ({ page }) => {
+    await page.goto(`${gameDriver.baseURL}/`);
+    await expect(page.locator('[data-id="version"]')).toHaveText(`v${VERSION}`);
+});
 
 test('start and stop a game', async ({ page }) => {
     await page.goto(`${gameDriver.baseURL}/`);


### PR DESCRIPTION
Closes #1295

## Summary

- **New `.github/workflows/release.yml`**: triggered on push of a `v*` tag. Builds the project the same way as `ci-cd.yml`'s `Build` job (`npm ci && npm run build && npm run pkg`), then creates a GitHub Release for the tag and uploads `dist/exec/starwards.exe` as a release asset, via `actions/github-script` (matches the existing convention in `deploy.yml` — no new third-party action dependency). `ci-cd.yml` is unchanged.
- **`VERSION` export from `@starwards/core`**: `modules/core/src/version.ts` reads the version straight from `modules/core/package.json` at build time (same version `scripts/release.sh` bumps). Exported from both `index.ts` and `index.public.ts` — the browser's webpack build resolves the bare `@starwards/core` specifier to `modules/core/src` via `tsconfig-paths-webpack-plugin`, which lands on `index.ts`, so the export needed to be added there too (not just the public barrel) for the browser bundle to see it.
- **Lobby version display**: `modules/browser/src/components/lobby.tsx` shows `v{VERSION}` unobtrusively in the bottom-right corner, `data-id="version"`.
- **README "Download & run" section**: points non-developer users at the [Releases page](https://github.com/starwards/starwards/releases) first, keeps the CI-artifact route as a documented fallback (still useful for testing unreleased commits), and mentions the local `npm run build && npm run pkg` path.

## Tests

- `modules/core/test/version.spec.ts` (new): `VERSION` matches `package.json`'s `version` field. Confirmed RED (module didn't exist) before adding `src/version.ts`.
- `modules/e2e/test/integration.spec.ts`: new `lobby shows the running game version` test asserting `[data-id="version"]` has text `v${VERSION}`. Confirmed RED against a build without the lobby change (temporarily stashed) before restoring it — GREEN after.

## Verification (run locally)

- `npm run test:types` — clean
- `npm run test:format` — clean
- `npm run build` — all modules build
- `npm test` — 38 suites, 350 passed + 2 skipped, 0 failures
- `npm run test:e2e` (functional specs; visual/gallery snapshot tests require the docker-based `snapshots:ci` flow per `CLAUDE.md` and weren't run in this sandbox) — 32/32 passed, plus the 2 in `integration.spec.ts`
- `.github/workflows/release.yml` — parsed with `js-yaml` to confirm valid syntax

## Out of scope (per issue)

- Linux/macOS binaries
- Docker/k8s deployment (`deploy.yml`)
- Any change to `scripts/release.sh` or npm publishing

🤖 Automated by Claude Code
https://claude.ai/code/session_014YmAkEho2kpkqqShPLa7hF

---
_Generated by [Claude Code](https://claude.ai/code/session_014YmAkEho2kpkqqShPLa7hF)_