### PR TITLE
fix: show broken (offline) systems in damage report widget (closes #1233)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -45,6 +45,11 @@ module.exports = {
         },
         {
             ...baseConfig,
+            displayName: 'browser',
+            testRegex: 'modules/browser/.*\\.spec\\.ts$',
+        },
+        {
+            ...baseConfig,
             displayName: 'deploy',
             testRegex: '\\.github/k8s/.*\\.spec\\.ts$',
         },

--- a/modules/browser/src/widgets/damage-report-logic.ts
+++ b/modules/browser/src/widgets/damage-report-logic.ts
@@ -1,0 +1,7 @@
+import { System } from '@starwards/core';
+
+export type BrokenSystemInfo = { pointer: string; name: string };
+
+export function getBrokenSystems(systems: readonly System[]): BrokenSystemInfo[] {
+    return systems.filter((s) => s.state.broken).map((s) => ({ pointer: s.pointer, name: s.state.name }));
+}

--- a/modules/browser/src/widgets/damage-report.tsx
+++ b/modules/browser/src/widgets/damage-report.tsx
@@ -7,6 +7,8 @@ import { DashboardWidget } from './dashboard';
 import { ShipDriver } from '@starwards/core';
 import WebFont from 'webfontloader';
 import { createMachine } from 'xstate';
+import { getBrokenSystems } from './damage-report-logic';
+import { readProp } from '../property-wrappers';
 import { useMachine } from '@xstate/react';
 
 WebFont.load({
@@ -66,11 +68,26 @@ function SystemStatusReport({ name, status, isOk }: { name: string; status: stri
         </>
     );
 }
+function SystemOfflineReport({ name }: { name: string }) {
+    return (
+        <>
+            <Text>
+                --------------------------
+                <br />
+                <b>{name} :</b> OFFLINE
+            </Text>
+            <br />
+        </>
+    );
+}
+
 function AllReports({ driver }: { driver: ShipDriver }) {
     const divRef = useRef<null | HTMLDivElement>(null);
     const defectsState = useProperties(driver.systems.flatMap((s) => s.defectibles).map(defectReadProp(driver))).sort(
         (a, b) => a.alertTime - b.alertTime,
     );
+    useProperties(driver.systems.map((s) => readProp<boolean>(driver, `${s.pointer}/broken`)));
+    const brokenSystems = getBrokenSystems(driver.systems);
     return (
         <>
             <>
@@ -79,6 +96,9 @@ function AllReports({ driver }: { driver: ShipDriver }) {
                 </Text>
                 <br />
             </>
+            {brokenSystems.map((s) => (
+                <SystemOfflineReport key={s.pointer} name={s.name} />
+            ))}
             {defectsState.map((d) => (
                 <SystemStatusReport key={d.pointer} name={d.name} status={d.status} isOk={d.isOk} />
             ))}

--- a/modules/browser/test/damage-report.spec.ts
+++ b/modules/browser/test/damage-report.spec.ts
@@ -1,0 +1,26 @@
+import { System } from '@starwards/core';
+import { getBrokenSystems } from '../src/widgets/damage-report-logic';
+
+function makeSystem(name: string, broken: boolean): System {
+    return {
+        pointer: `/${name}`,
+        state: { name, broken } as System['state'],
+        defectibles: [],
+        getStatus: () => (broken ? 'DISABLED' : 'OK'),
+        getHeatStatus: () => 'OK',
+    };
+}
+
+describe('getBrokenSystems', () => {
+    test('returns nothing when no systems are broken', () => {
+        expect(getBrokenSystems([makeSystem('radar', false), makeSystem('warp', false)])).toEqual([]);
+    });
+
+    test('returns only the broken systems, with name and pointer', () => {
+        const systems = [makeSystem('radar', true), makeSystem('warp', false), makeSystem('reactor', true)];
+        expect(getBrokenSystems(systems)).toEqual([
+            { pointer: '/radar', name: 'radar' },
+            { pointer: '/reactor', name: 'reactor' },
+        ]);
+    });
+});


### PR DESCRIPTION
Closes #1233

## Summary

- The damage report widget (`modules/browser/src/widgets/damage-report.tsx`) only listed individual defect properties that were off their normal value. A system marked `broken` (fully offline, per `SystemState.broken`) with no *currently deviating* defect fields showed nothing, so players had no way to see a system was disabled.
- New `getBrokenSystems()` in `modules/browser/src/widgets/damage-report-logic.ts` — a small, dependency-light pure function (kept out of the `.tsx` file so it doesn't pull in `pixi.js`/Arwes for unit testing) that filters `driver.systems` down to the ones currently `broken`.
- `AllReports` now watches each system's `${pointer}/broken` property (same event already wired by `ShipDriver`, see `modules/core/src/client/ship.ts`) and renders a persistent `<name> : OFFLINE` line above the existing (transient, fading) defect list for every broken system.
- Added a `browser` Jest project (`jest.config.js`) since no browser unit tests existed before — mirrors the shape used elsewhere in this repo (server/core/node-red projects).

## Tests

`modules/browser/test/damage-report.spec.ts` (2 tests) — confirmed RED first (`getBrokenSystems` didn't exist, module-not-found), then implemented:
- `returns nothing when no systems are broken`
- `returns only the broken systems, with name and pointer`

## Verification

- `npm run test:types` — clean
- `npm run test:format` — clean
- `npm run build` — all modules build
- `npm test` — 40 suites, 365 passed + 2 skipped, 0 failures
- `npm run test:e2e` — 75 passed, 6 skipped (OSC bridge tests requiring node-red), 0 failures

🤖 Automated by Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nm2R1cKmodNWATiJbMfdvG)_