### PR TITLE
fix: restore time-windowed event salt in ShipDie (closes #1980)

### DIFF
--- a/modules/core/src/logic/hash.ts
+++ b/modules/core/src/logic/hash.ts
@@ -23,3 +23,18 @@ export function mix(a: number, b: number): number {
     h ^= h >>> 16;
     return h >>> 0;
 }
+
+/**
+ * Scramble a single 32-bit integer into a new, well-avalanched 32-bit integer.
+ * The MurmurHash3 finalizer: a single-bit change in the input flips roughly
+ * half the output bits.
+ */
+export function scramble(x: number): number {
+    let h = x >>> 0;
+    h ^= h >>> 16;
+    h = Math.imul(h, 0x85ebca6b) >>> 0;
+    h ^= h >>> 13;
+    h = Math.imul(h, 0xc2b2ae35) >>> 0;
+    h ^= h >>> 16;
+    return h >>> 0;
+}

--- a/modules/core/src/ship/ship-die.ts
+++ b/modules/core/src/ship/ship-die.ts
@@ -1,7 +1,12 @@
 import { IterationData, Updateable } from '../updateable';
-import { fnv1a, mix } from '../logic/hash';
+import { fnv1a, mix, scramble } from '../logic/hash';
 import { hashToUnit } from '../logic/prng';
 import { valueNoise1D } from '../logic/noise';
+
+/**
+ * Width of the event-salt window, in game-time seconds (see class doc).
+ */
+const EVENT_SALT_WINDOW_SECONDS = 3;
 
 /**
  * Deterministic "chaos" die.
@@ -9,36 +14,59 @@ import { valueNoise1D } from '../logic/noise';
  * Two kinds of rolls:
  *
  *  - `getRoll / getRollInRange / getSuccess` — **event rolls**.
- *    Pure hash of `(seed, id)`. Independent of time. Same `id` always
- *    yields the same value, for the entire lifetime of that id. Intended
- *    for one-off events whose identity is captured by the id string
- *    (e.g. `'damageManeuvering:' + damageEventId`).
+ *    Hash of `(eventSalt, id)`, where `eventSalt` advances once every
+ *    `EVENT_SALT_WINDOW_SECONDS` of accumulated game time. Within one
+ *    window a given `id` always yields the same value ("stickiness
+ *    quantum"); across windows it decorrelates. This makes a
+ *    time-stretched phenomenon that rolls the same id every tick (e.g. a
+ *    lingering explosion emitting one damage event per tick) cohere into
+ *    one event-like outcome for the whole window, with a rare legitimate
+ *    switch when it straddles a window boundary — without eternally
+ *    freezing a phenomenon that failed its roll once.
+ *
+ *    The caller chooses stickiness through the key: a bare phenomenon id
+ *    (e.g. `pickSystem:${damageId}`) is sticky — repeated rolls during a
+ *    window agree, so a stream coheres onto one outcome. An id carrying a
+ *    counter/index (e.g. `defect:${id}:${appIdx}:${system}:${rollIdx}`)
+ *    is fresh — deliberately decorrelated per application, for magnitudes
+ *    that must accumulate linearly rather than repeat all-or-nothing
+ *    within a window.
  *
  *  - `getDrift / getDriftInRange` — **drift rolls**.
- *    Smoothly varying in game time. Sampled as 1-D value noise at
- *    `noise(hash(id), gameTime * freq)`. Each channel has its own
- *    hash-derived phase so channels do not re-sync. Intended for
- *    continuous environmental jitter (smart-pilot aim, radar flicker).
+ *    Smoothly varying in game time, keyed off the die's immutable seed
+ *    (not the event salt) so channels never jump when the salt rotates.
+ *    Sampled as 1-D value noise at `noise(hash(id), gameTime * freq)`.
+ *    Each channel has its own hash-derived phase so channels do not
+ *    re-sync. Intended for continuous environmental jitter (smart-pilot
+ *    aim, radar flicker).
  *
- * The die is deterministic given its inputs (seed, id, time). It does
- * NOT attempt to deliver end-to-end simulation determinism — game-loop
- * tick timing, collision ordering and OS scheduling introduce their own
- * real-world chaos upstream of the die.
+ * The die is deterministic given its inputs (seed, id, update sequence).
+ * It does NOT attempt to deliver end-to-end simulation determinism —
+ * game-loop tick timing, collision ordering and OS scheduling introduce
+ * their own real-world chaos upstream of the die.
  */
 export class ShipDie implements Updateable {
     private gameTime = 0;
     private readonly seed: number;
+    private eventSalt: number;
+    private eventWindowIndex = 0;
 
     constructor(seed?: number) {
         this.seed = (seed ?? (Math.random() * 0x100000000) >>> 0) >>> 0;
+        this.eventSalt = this.seed;
     }
 
     public update({ deltaSeconds }: IterationData) {
         this.gameTime += deltaSeconds;
+        const windowIndex = Math.floor(this.gameTime / EVENT_SALT_WINDOW_SECONDS);
+        while (this.eventWindowIndex < windowIndex) {
+            this.eventSalt = scramble(this.eventSalt);
+            this.eventWindowIndex++;
+        }
     }
 
     public getRoll(id: string): number {
-        return hashToUnit(mix(this.seed, fnv1a(id)));
+        return hashToUnit(mix(this.eventSalt, fnv1a(id)));
     }
 
     public getRollInRange(id: string, min: number, max: number): number {

--- a/modules/core/test/hash.spec.ts
+++ b/modules/core/test/hash.spec.ts
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+import { scramble } from '../src/logic/hash';
+
+function popcount(x: number): number {
+    let count = 0;
+    let v = x >>> 0;
+    while (v) {
+        count += v & 1;
+        v >>>= 1;
+    }
+    return count;
+}
+
+describe('scramble', () => {
+    it('is deterministic', () => {
+        expect(scramble(12345)).to.equal(scramble(12345));
+    });
+
+    it('avalanches: single-bit input changes flip roughly half the output bits on average', () => {
+        const samples = 200;
+        let totalFlippedBits = 0;
+        for (let i = 0; i < samples; i++) {
+            const base = (i * 2654435761) >>> 0;
+            const bitToFlip = i % 32;
+            const flipped = base ^ (1 << bitToFlip);
+            const diff = (scramble(base) ^ scramble(flipped >>> 0)) >>> 0;
+            totalFlippedBits += popcount(diff);
+        }
+        const avgFlippedBits = totalFlippedBits / samples;
+        // 32 bits total; a good avalanche keeps the average close to 16.
+        expect(avgFlippedBits).to.be.within(12, 20);
+    });
+});

--- a/modules/core/test/ship-die.spec.ts
+++ b/modules/core/test/ship-die.spec.ts
@@ -1,6 +1,8 @@
 import { ShipDie } from '../src/ship/ship-die';
 import { expect } from 'chai';
 
+const EVENT_SALT_WINDOW_SECONDS = 3;
+
 function tick(die: ShipDie, deltaSeconds: number) {
     die.update({ deltaSeconds, deltaSecondsAvg: deltaSeconds, totalSeconds: 0 });
 }
@@ -21,13 +23,44 @@ describe('ShipDie', () => {
             expect(samples.size).to.be.greaterThan(12);
         });
 
-        it('getRoll is stable across update() calls (regression for 3 s flip bug)', () => {
+        it('same id, no update() between rolls ⇒ identical value (within-window stability)', () => {
+            const die = new ShipDie(7);
+            const first = die.getRoll('damageSystem:abc');
+            expect(die.getRoll('damageSystem:abc')).to.equal(first);
+            expect(die.getRoll('damageSystem:abc')).to.equal(first);
+        });
+
+        it('rolls are stable across update() calls that stay within one salt window', () => {
             const die = new ShipDie(7);
             const first = die.getRoll('damageSystem:abc');
             for (let i = 0; i < 10; i++) {
-                tick(die, 1); // ten seconds — old bug: wiped every 3 s
+                tick(die, 0.1); // 10 x 0.1s = 1s, well within the 3s window
+                expect(die.getRoll('damageSystem:abc')).to.equal(first);
             }
-            expect(die.getRoll('damageSystem:abc')).to.equal(first);
+        });
+
+        it('same id, sampled across several salt windows ⇒ decorrelates (at least two distinct values)', () => {
+            const die = new ShipDie(7);
+            const values = new Set<number>();
+            values.add(die.getRoll('damageSystem:abc'));
+            for (let w = 0; w < 5; w++) {
+                tick(die, EVENT_SALT_WINDOW_SECONDS + 0.001);
+                values.add(die.getRoll('damageSystem:abc'));
+            }
+            expect(values.size).to.be.greaterThan(1);
+        });
+
+        it('replay determinism: two dice, same seed, same update sequence ⇒ identical roll sequences', () => {
+            const a = new ShipDie(55);
+            const b = new ShipDie(55);
+            const stepsSeconds = [0.1, 0.2, 3.05, 0.1, 6.2, 1, 0.1];
+            for (const dt of stepsSeconds) {
+                tick(a, dt);
+                tick(b, dt);
+                expect(a.getRoll('id-1')).to.equal(b.getRoll('id-1'));
+                expect(a.getSuccess('id-2', 0.4)).to.equal(b.getSuccess('id-2', 0.4));
+                expect(a.getRollInRange('id-3', -5, 5)).to.equal(b.getRollInRange('id-3', -5, 5));
+            }
         });
 
         it('getRollInRange maps into the requested range', () => {
@@ -55,6 +88,17 @@ describe('ShipDie', () => {
             }
             // Expected ~600; allow generous slack.
             expect(hits).to.be.within(450, 750);
+        });
+
+        it('getSuccess on one fixed id, sampled once per window across many windows, approaches the given probability (eternal-freeze regression)', () => {
+            const die = new ShipDie(321);
+            let hits = 0;
+            const windows = 200;
+            for (let w = 0; w < windows; w++) {
+                if (die.getSuccess('lingering-phenomenon', 0.3)) hits++;
+                tick(die, EVENT_SALT_WINDOW_SECONDS + 0.001);
+            }
+            expect(hits / windows).to.be.within(0.2, 0.4);
         });
     });
 
@@ -106,6 +150,37 @@ describe('ShipDie', () => {
                 expect(v).to.be.at.least(-180);
                 expect(v).to.be.lessThan(180);
             }
+        });
+
+        it('is unaffected by salt window rotation: equal gameTime ⇒ equal drift regardless of rotations crossed', () => {
+            // Reach the same absolute gameTime via two different paths: one that crosses
+            // several salt-window boundaries, one that lands there in a single step.
+            const targetSeconds = EVENT_SALT_WINDOW_SECONDS * 4 + 1.2345;
+
+            const stepped = new ShipDie(17);
+            for (let i = 0; i < 400; i++) tick(stepped, targetSeconds / 400);
+
+            const jumped = new ShipDie(17);
+            tick(jumped, targetSeconds);
+
+            expect(jumped.getDrift('radar', 0.5)).to.be.closeTo(stepped.getDrift('radar', 0.5), 1e-6);
+        });
+
+        it('shows no discontinuity in getDrift when a salt window boundary is crossed', () => {
+            const die = new ShipDie(8);
+            // Land just before a boundary.
+            tick(die, EVENT_SALT_WINDOW_SECONDS - 0.01);
+            const before = die.getDrift('radar', 0.2);
+            tick(die, 0.02); // crosses the boundary
+            const across = die.getDrift('radar', 0.2);
+            tick(die, 0.02); // same step size, away from the boundary
+            const after = die.getDrift('radar', 0.2);
+
+            const stepAtBoundary = Math.abs(across - before);
+            const stepAwayFromBoundary = Math.abs(after - across);
+            // The boundary-crossing step should be of the same order as a normal step,
+            // not a jump caused by the salt rotating.
+            expect(stepAtBoundary).to.be.lessThan(stepAwayFromBoundary + 0.05);
         });
     });
 });


### PR DESCRIPTION
Closes #1980

## Summary

PR #1891 replaced `ShipDie`'s per-id roll cache with pure hashing (`(seed, id)`), which made event rolls eternal: an id that failed a roll once could never succeed on it, no matter how long the phenomenon lingered. This restores the original ~3s "stickiness quantum" window, but deterministically, without `Math.random()`:

- `ShipDie` now has two seeds: the immutable `seed` (used by drift rolls / replay identity) and a `eventSalt` that advances once every `EVENT_SALT_WINDOW_SECONDS = 3` of accumulated game time.
- `getRoll`/`getRollInRange`/`getSuccess` now hash off `eventSalt` instead of `seed` — a given id is stable within one window and decorrelates across windows.
- `getDrift`/`getDriftInRange` are untouched — still keyed off the immutable `seed` and `gameTime`, so drift channels never jump when the salt rotates.
- New `scramble(x: number): number` in `modules/core/src/logic/hash.ts` — a single-input MurmurHash3-finalizer-style avalanche step, used to advance `eventSalt` once per window.
- Rewrote the class doc comment to state the new contract explicitly, including the key-design rule: a bare phenomenon id (e.g. `pickSystem:${damageId}`) is sticky within a window; an id carrying a counter/index is deliberately fresh per application.

## Tests

- `modules/core/test/ship-die.spec.ts`: replaced the old "stable across update() calls" test (which pinned eternal id-stability across a 10s span) with:
  - within-window stability (10 × 0.1s updates, no window crossed)
  - decorrelation across ≥5 salt windows
  - replay determinism (two dice, same seed, same update sequence → identical roll sequences)
  - `getSuccess` frequency approaching `p` when sampled once per window across 200 windows (the eternal-freeze regression)
  - `getDrift` unaffected by salt rotation (same gameTime via different update paths → same drift)
  - no discontinuity in `getDrift` across a salt-window boundary
- `modules/core/test/hash.spec.ts` (new): `scramble` determinism + avalanche sanity check (single-bit input flips ≈half the output bits on average).

## Verification

- `npm run test:types` — clean
- `npm run test:format` — clean
- `npm run build` — all modules build
- `npm test` — 46 suites, 427 passed + 2 skipped, 0 failures
- `npm run knip` — clean

## Out of scope (per issue)

Window length tuning, drift semantics, damage-manager key changes, and the spillover defect-counter work (on `agent/issue-1976`) — no changes expected there; the per-application counter keys already decorrelate independent of this fix.

🤖 Automated by Claude Code
https://claude.ai/code/session_01EVvMEAkh9ytBGi7HdgSw6r


---
_Generated by [Claude Code](https://claude.ai/code/session_01EVvMEAkh9ytBGi7HdgSw6r)_