### PR TITLE
feat: add widgets gallery link to lobby utilities

### DIFF
--- a/modules/browser/src/components/lobby.tsx
+++ b/modules/browser/src/components/lobby.tsx
@@ -184,6 +184,13 @@ export const Lobby = (p: Props) => {
                             >
                                 Colyseus Monitor
                             </Button>
+                            <Button
+                                key="gallery"
+                                palette="secondary"
+                                onClick={() => window.location.assign('gallery.html')}
+                            >
+                                Widgets Gallery
+                            </Button>
                         </pre>
                     </div>
                     <div


### PR DESCRIPTION
## Summary
- Add a "Widgets Gallery" button to the lobby Utilities section (alongside Input and Colyseus Monitor), linking to `gallery.html`.
- The gallery ships in every production build (webpack `gallery` entry → `post-build.js` copies browser dist into served `static/`), so the link works on deployed servers too.
- `gallery.html` opens with its own scene-selector pane, so no query params needed.

## Testing
- `npm run test:types` passes
- ESLint clean on the edited file

🤖 Generated with [Claude Code](https://claude.com/claude-code)