### PR TITLE
docs: staleness sweep 2026-07-20 — sync docs with merged armor/ammo/heat/scan work

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -8,7 +8,7 @@ source_of_truth:
 related:
   - TECHNICAL_REFERENCE.md
   - LLM_CONTEXT.md
-last_verified: 2026-06-13
+last_verified: 2026-07-20
 ---
 
 # API Reference
@@ -100,7 +100,7 @@ efficiency = 1;
 
 **AI:** `isPlayerShip|idleStrategy|order|orderTargetId|orderPosition|currentTask`
 
-**Systems:** `thrusters|tubes|chainGun|radar|reactor|smartPilot|armor|magazine|weaponsTarget|warp|docking|maneuvering`
+**Systems:** `thrusters|tubes|chainGun|radar|reactor|smartPilot|armor|magazine|weaponsTarget|warp|docking|maneuvering|signals`
 
 **Controls:** `rotation:[-1,1]|boost:[-1,1]|strafe:[-1,1]|antiDrift:[0,1]|breaks:[0,1]|afterBurner:[0,1]`
 

--- a/docs/PHYSICS.md
+++ b/docs/PHYSICS.md
@@ -6,7 +6,7 @@ source_of_truth:
   - modules/core/src/logic/xy.ts
 related:
   - SUBSYSTEMS.md
-last_verified: 2026-06-13
+last_verified: 2026-07-20
 ---
 
 # Physics System
@@ -136,23 +136,32 @@ Weapons are designed for specific effectiveness ranges:
 ## Damage System
 
 ### Damage Application
-```typescript
-function applyDamage(target: Spaceship, damage: number, hitPos: Position) {
-    const hitAngle = angleFromCenter(target.position, hitPos);
-    const plate = findClosestArmorPlate(target.armor, hitAngle);
-    plate.health -= damage;
 
-    if (plate.health <= 0) {
-        plate.broken = true;
-        const penetration = -plate.health * PENETRATION_FACTOR;
-        damageRandomSystem(target, penetration);
+Weapon hits resolve in `DamageManager.takeWeaponDamage()` (`modules/core/src/ship/damage-manager.ts`):
+
+```typescript
+takeWeaponDamage(damage: AttackDamage) {
+    applySurfaceEffect(damage);          // hull-mounted (external) systems scraped regardless of armor
+    for (const hitArea of shipAreasInRange(damage.damageSurfaceArc)) {  // front / rear
+        exposure = walkArmorLayers(damage, areaHitRange);  // 0..1 leak-through per area
     }
+    applyExposedSystemDamage(damage, exposures);  // post-armor system defects
 }
 ```
 
+`walkArmorLayers()` walks the armor stack outermost-in over `Armor.layerDesigns`. Each layer's response to the incoming damage type (`ArmorLayerDesignState.response()`) decides the outcome:
+
+- **bypass** — layer is transparent to this damage type; skipped
+- **block** — stops the walk; only already-broken sections leak inward
+- **engage** — plates erode (`damage.amount × plateFactor × chain`) and damage leaks through via `max(penetration, brokenLayerRatio)`
+
+Exposure chains multiplicatively across the stack; the final chain scales system damage for the area. Reactive layers (`singleUsePlates`) trigger on impact delivery only: one cell pops and defeats the whole hit (exposure measured pre-pop) unless the round fully penetrates (Tandem); explosions erode reactive cells like ordinary plates.
+
+Post-armor damage goes through `applyExposedSystemDamage()` → `damageSystem()`: the damage profile's `systemScope` picks targets (a single random system, all systems in the exposed area, or ship-wide electronics), and each application is walked off in `damage50`-sized steps of probabilistic `@defectible` rolls (each capped at 50%) — no direct health subtraction on systems.
+
 ### Sectional Armor
 
-Armor is modeled as N equal radial plates stored in an `ArraySchema<ArmorPlate>` (e.g. 12 plates for the dragonfly "Aegis-12" design). Each plate spans `360/numberOfPlates` degrees, with its angular position derived from its array index rather than a stored angle. Plates carry only `health` and `maxHealth` (no angle field) and share a uniform `plateMaxHealth` from the armor design config — not four fixed front/right/rear/left plates with distinct hardcoded health values (100/80/70/80).
+Armor is modeled as N equal radial plates stored in an `ArraySchema<ArmorPlate>` (`modules/core/src/ship/armor.ts`; e.g. 12 plates for the dragonfly design). Each plate spans `360/numberOfPlates` degrees, with its angular position derived from its array index rather than a stored angle. Each plate holds `layers = ArraySchema<ArmorLayer>` — outermost first, indexed in lockstep with `Armor.layerDesigns` — and each layer carries `health`/`maxHealth`, with `plateMaxHealth` set per layer by the matching `ArmorLayerDesignState`. `plate.broken` is a getter: true only when every layer of the plate is down.
 
 ## Explosion Propagation
 

--- a/docs/SUBSYSTEMS.md
+++ b/docs/SUBSYSTEMS.md
@@ -6,7 +6,7 @@ source_of_truth:
 related:
   - PHYSICS.md
   - API_REFERENCE.md
-last_verified: 2026-06-13
+last_verified: 2026-07-20
 ---
 
 # Ship Subsystems
@@ -50,11 +50,12 @@ last_verified: 2026-06-13
 | **ChainGun** | `chain-gun.ts` | isFiring, loadAmmo, loading, rateOfFireFactor | Rapid-fire kinetic |
 | **Tubes** | `tube.ts` | angle, index (inherits loading, rateOfFireFactor, loadedProjectile from ChainGun) | Missile launchers (array) |
 | **Magazine** | `magazine.ts` | capacity, missiles | Ammo storage |
-| **Armor** | `armor.ts` | armorPlates[], numberOfHealthyPlates, numberOfPlates | Sectional damage |
+| **Armor** | `armor.ts` | armorPlates[] (each: layers[] of health/maxHealth), layerDesigns[], numberOfHealthyPlates, numberOfPlates | Sectional damage, layered plate stacks |
 | **Targeting** | `targeting.ts` | targetId, shipOnly, enemyOnly, shortRangeOnly | Weapon targeting |
 | **Warp** | `warp.ts` | currentLevel, desiredLevel, velocityFactor, damageFactor | FTL travel |
 | **Docking** | `docking.ts` | mode, targetId, rangesFactor | Ship-to-ship attach |
 | **SmartPilot** | `smart-pilot.ts` | rotationMode, maneuveringMode, rotation, maneuvering | Autopilot |
+| **Signals** | `signals.ts` (+ `signals-job.ts`, `signals-job-manager.ts`) | jobs[], trackedTargets[], jobSuccessFactor, jobSpeedFactor, currentMaxJobs | SCAN/HACK job queue, target tracking, scan levels |
 
 ## Pilot Controls
 **Location:** `modules/core/src/ship/ship-state.ts`
@@ -117,12 +118,16 @@ systems.forEach(sys => {
 
 ### Damage Propagation
 ```typescript
-armor.takeDamage(damage, hitAngle);
-
-if (armor.isBroken(hitAngle)) {
-    const internalDamage = damage × ARMOR_PENETRATION_FACTOR;
-    randomSystem.broken = true;
+// DamageManager.takeWeaponDamage (modules/core/src/ship/damage-manager.ts)
+for (const hitArea of shipAreasInRange(damage.damageSurfaceArc)) {   // front / rear
+    // walk armor layers outermost-in; per damage type each layer bypasses,
+    // blocks, or engages (plates erode, damage leaks via max(penetration, brokenRatio))
+    exposure = walkArmorLayers(damage, areaHitRange);   // 0..1 leak-through
 }
+// systemScope picks targets: single random system, all in area, or ship-wide electronics
+applyExposedSystemDamage(damage, exposures);
+// → damageSystem(): amount × exposure walked off in damage50-sized steps,
+//   each a probabilistic @defectible roll (capped at 50%) — no direct "broken = true"
 ```
 
 ## Damage Philosophy

--- a/docs/UI_SPECIFICATION.md
+++ b/docs/UI_SPECIFICATION.md
@@ -1,7 +1,7 @@
 # Starwards SBS UI Specification
 
 **Version:** 1.0
-**Date:** 2025-10-22
+**Date:** 2026-07-20
 **Purpose:** Comprehensive specification of all UI screens and components
 
 ---
@@ -136,7 +136,7 @@ The Pilot screen provides flight controls, navigation instruments, and situation
   - Divided into plates (default 8 plates)
   - Real-time health updates
 - **Size**: 200px minimum width
-- **Data Source**: `/armor/armorPlates[*]/health`, `/armor/design/plateMaxHealth`
+- **Data Source**: `/armor/armorPlates[*]/layers[*]/health`, `/armor/layerDesigns[*]/plateMaxHealth`
 
 #### 5. Warp Status Panel (Middle-Right)
 - **Widget**: `drawWarpStatus()` - Tweakpane panel

--- a/docs/bridge-playtest/bridge-eng-design.md
+++ b/docs/bridge-playtest/bridge-eng-design.md
@@ -150,7 +150,7 @@ or gate this back-door.
 |---|---|---|
 | #1228 malfunction API | ✅ closed | Built the `@defectible` annotation infrastructure that the user's repair UI would consume. Ticket body explicitly listed "logic / measurement for fixing damage? (for future repair station, #547)" — i.e., the foundation was laid for #547 but never used. |
 | #1232 (referenced by #1233) | not in repo | Predecessor that introduced the damage-report widget. |
-| #1233 add broken status to damage-report widget | ❌ open | Trivial addition: surface the `broken` (DISABLED) attribute alongside defectibles in the existing widget. Compatible with the user's D1 — would land naturally as part of the engineering-station mount. |
+| #1233 add broken status to damage-report widget | ✅ closed (PR #1974) | `damage-report.tsx` now surfaces broken systems via `getBrokenSystems` alongside defectibles. Compatible with the user's D1 — would land naturally as part of the engineering-station mount. |
 | #547 repair station | ❌ open (was blocked by #1228, now unblocked) | **Direct overlap with user intent.** Ticket text: *"repair widgets / minigames. preferably behind a network API (IoT?)."* The ticket assumes a **separate** ship station; user is proposing to put repair on the **bridge engineering** station instead. |
 | #543 Fighters field repair | ✅ closed (2026-04-13) | Different scope (fighters, GM-button-press). Not relevant to the bridge proposal. |
 | #545 Fighters in-station repair | ✅ closed (2026-04-13) | Different scope. Not relevant. |
@@ -220,8 +220,8 @@ prioritization pressure, no failure mode.
 
 ## 5. Tickets relevant to closing the gap
 
-- **#1233** open — surface `broken` status in damage-report widget.
-  Trivial; lands first regardless of larger decision.
+- **#1233** ✅ closed (PR #1974) — `broken` status now surfaced in the
+  damage-report widget.
 - **#547** open (now unblocked) — central decision: keep as a
   separate post-bridge station, or re-scope onto bridge engineering.
 - New ticket(s) likely needed for:

--- a/docs/bridge-playtest/bridge-eng.md
+++ b/docs/bridge-playtest/bridge-eng.md
@@ -75,8 +75,8 @@ time can change power/coolant.
 
 | Ticket | Status | Title | Bridge-Eng relevance |
 |---|---|---|---|
-| #1233 | open | broken status in damage report widget | `fullSystemsStatus` already shows `broken` via `statusChangeProps`; ticket may apply to a separate damage-report widget not used here — verify |
-| #968 | open | Armor adjustments | binary plate state + degenerate armor model — would change `armorStatus` rendering |
+| #1233 | ✅ closed (PR #1974) | broken status in damage report widget | `damage-report.tsx` now renders broken systems via `getBrokenSystems`; `fullSystemsStatus` already showed `broken` via `statusChangeProps` |
+| #968 | open | Armor adjustments | armor is now layered continuous per-plate/per-layer health (`ArmorPlate`/`ArmorLayer` in `armor.ts`, PR #1932) — would change `armorStatus` rendering |
 | #788 | open | QA armor behavior | testing/validation only |
 | #1239 | open | composition vs inheritance refactor | architectural; no direct UI change but flagged as high risk in MS3 PLAN |
 

--- a/docs/bridge-playtest/decisions.md
+++ b/docs/bridge-playtest/decisions.md
@@ -6,7 +6,7 @@ Confirmed decisions only. Candidates and drafts live in [`proposals.md`](proposa
 
 Agreed order of upcoming work (Amir + Daniel, 2026-07-04):
 
-1. **Merge the ammo-type × armor-type damage metrics.** Land the new per-pair damage mechanic (see the 2026-05-03 armor×ammo decision below). Daniel's concrete draft is [#1929](https://github.com/starwards/starwards/issues/1929) (5 armor types × 8 ammo types, full damage matrix); implementation is pending in [PR #1932](https://github.com/starwards/starwards/pull/1932). Merging that PR is the immediate next step.
+1. **Merge the ammo-type × armor-type damage metrics.** Land the new per-pair damage mechanic (see the 2026-05-03 armor×ammo decision below). Daniel's concrete draft is [#1929](https://github.com/starwards/starwards/issues/1929) (5 armor types × 8 ammo types, full damage matrix); implementation is pending in [PR #1932](https://github.com/starwards/starwards/pull/1932). Merging that PR is the immediate next step. *Status 2026-07-15: PR #1932 merged — 5 armor models and 9 ammo types (3 shells + 6 missiles) shipped, with per-layer damage resolution, per-ammo heat, and per-ammo magazine capacity.*
 2. **Design the player ship — the corvette (Gravitas).** Make it interesting and durable for play: it must survive and stay engaging across a full session, not just a dogfight.
 3. **Add the Signals radar beam.** The directional beam at the Signals station (see the tier-2 EW scan beam in the 2026-05-03 scan-tiers decision below).
 
@@ -39,7 +39,7 @@ Future features discussed in the same talk (probes, railgun, torpedo) are drafte
 - **Weapons**: receives the call, selects matching ammo, fires.
 - Replaces the "shield frequency equivalent" slot in the gap-closing plan.
 
-**Counts.** Multiple armor types and multiple ammo types (missiles + cannon shells). Concrete counts owned by Daniel — draft landed as [#1929](https://github.com/starwards/starwards/issues/1929) (5 armor types, 8 ammo types, Resist/Normal/Vulnerable/Critical/Ignores matrix). Intent: asymmetric ammo↔armor mapping (no clean 1:1) so some ammo is strong vs. multiple armors and weak vs. others, forcing real Weapons judgment rather than lookup.
+**Counts.** Multiple armor types and multiple ammo types (missiles + cannon shells). Concrete counts owned by Daniel — draft landed as [#1929](https://github.com/starwards/starwards/issues/1929) (5 armor types, 8 ammo types, Resist/Normal/Vulnerable/Critical/Ignores matrix); shipped as 5 armor models × **9** ammo types via PR #1932 (merged 2026-07-15). Intent: asymmetric ammo↔armor mapping (no clean 1:1) so some ammo is strong vs. multiple armors and weak vs. others, forcing real Weapons judgment rather than lookup.
 
 **Status.** Direction agreed (Daniel, 2026-05-03). Open: full per-pair damage matrix, partial-match curve shape, per-ammo magazine slot allocation, in-flight reload swap rules.
 
@@ -69,7 +69,7 @@ Future features discussed in the same talk (probes, railgun, torpedo) are drafte
 
 **Decision.** Firing weapons produces **significant heat in the weapon subsystem**. Heat is the primary DPS limiter — sustained fire forces a cooldown beat or risks self-damage.
 
-**Chain.** `fire → heat → (if unchecked) overheat damage → malfunction`. Reuses the existing heat→damage→malfunction infrastructure (`HeatManager.addHeat`, overheat damages the system above `MAX_SYSTEM_HEAT = 100`, which then becomes broken/malfunctioning). Today `chain-gun.ts` does not call `addHeat`; this decision adds that call (and an analogous one for missiles).
+**Chain.** `fire → heat → (if unchecked) overheat damage → malfunction`. Reuses the existing heat→damage→malfunction infrastructure (`HeatManager.addHeat`, overheat damages the system above `MAX_SYSTEM_HEAT = 100`, which then becomes broken/malfunctioning). This call has since landed (#1923, merged via #1930): `chain-gun-manager.ts` calls `addHeat(heatPerShot * effectiveness, chainGun)` on fire.
 
 **Per-shot heat values.** Should differ by ammo type — heavier rounds run hotter. Specific values TBD.
 

--- a/docs/bridge-playtest/plan.md
+++ b/docs/bridge-playtest/plan.md
@@ -14,11 +14,11 @@ For deferred ideas, see [`proposals.md`](proposals.md).
 
 | ID         | Task                                                     | Blocked on |
 | ---------- | -------------------------------------------------------- | ---------- |
-| A1 **[D]** | Armor plate types: names, properties, visual identity    | —          |
-| A2 **[D]** | Ammo types (missiles + cannon shells): names, properties | —          |
-| A3 **[D]** | Full armor × ammo damage matrix                          | A1 + A2    |
-| A4 **[D]** | Per-ammo heat-per-shot values                            | A2         |
-| A5 **[D]** | Per-ammo magazine capacity rules (per-ship-design)       | A2         |
+| ~~A1~~     | ~~Armor plate types: names, properties, visual identity~~ — **done** (shipped via PR #1932, 2026-07; 5 armor models in `armor-models.ts`)         | —          |
+| ~~A2~~     | ~~Ammo types (missiles + cannon shells): names, properties~~ — **done** (shipped via PR #1932, 2026-07; 3 shells + 6 missiles in `projectile.ts`) | —          |
+| ~~A3~~     | ~~Full armor × ammo damage matrix~~ — **done** (shipped via PR #1932, 2026-07; resolved per-layer in `damage-manager.ts`)                         | —          |
+| ~~A4~~     | ~~Per-ammo heat-per-shot values~~ — **done** (shipped via PR #1932, 2026-07; `heatPerShot` per ammo design)                                       | —          |
+| ~~A5~~     | ~~Per-ammo magazine capacity rules (per-ship-design)~~ — **done** (shipped via PR #1932, 2026-07; `max_*` fields in `magazine.ts`)                | —          |
 
 Output: design spec docs in `docs/bridge-playtest/`.
 
@@ -46,21 +46,21 @@ Output: design notes captured to `docs/bridge-playtest/`.
 
 | ID           | Task                                                                                                     | GitHub                                                      |
 | ------------ | -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| C1.1 **[C]** | Wire `addHeat()` calls into chain-gun + missile firing path (placeholder per-ammo values)                | [#1923](https://github.com/starwards/starwards/issues/1923) |
+| ~~C1.1~~     | ~~Wire `addHeat()` calls into chain-gun + missile firing path~~ — **done** (merged via #1930)            | [#1923](https://github.com/starwards/starwards/issues/1923) |
 | ~~C1.2~~     | ~~Add `callsign` + `transponderOpen` fields to `Spaceship`, default open~~ — **done** (merged via #1927) | [#1924](https://github.com/starwards/starwards/issues/1924) |
-| C1.3 **[C]** | 5-second in-range timer for ScanLevel.UFO→BASIC promotion; gate on `transponderOpen`                     | [#1925](https://github.com/starwards/starwards/issues/1925) |
+| ~~C1.3~~     | ~~5-second in-range timer for ScanLevel.UFO→BASIC promotion; gate on `transponderOpen`~~ — **done** (merged via #1933) | [#1925](https://github.com/starwards/starwards/issues/1925) |
 | ~~C1.4~~     | ~~Ammo selection UI audit~~ — **done** (resolved by screenshot review on 2026-05-03)                     | —                                                           |
 
 ### Group C2 — needs Daniel (Track A)
 
 | ID           | Task                                                                                                            | Blocked on   |
 | ------------ | --------------------------------------------------------------------------------------------------------------- | ------------ |
-| C2.1 **[C]** | `ArmorType` enum + per-plate type assignment in schema and `make-ship-state.ts`                                 | A1           |
-| C2.2 **[C]** | Add new ammo types to `ammoDesigns`, `Magazine` (`max_*`/`count_*`), `chain-gun` (`use_*`)                      | A2           |
-| C2.3 **[C]** | Armor-type-aware damage matrix in `damage-manager.ts`                                                           | A1 + A2 + A3 |
-| C2.4 **[C]** | Per-ammo heat values from A4 wired into C1.1                                                                    | A4 + C1.1    |
-| C2.5 **[C]** | Magazine capacity per A5                                                                                        | A5           |
-| C2.6 **[C]** | Cycle UI improvements (persistent strip, magazine counts, next-preview, optional `Shift+B` / `Shift+V` reverse) | A2           |
+| ~~C2.1~~     | ~~`ArmorType` enum + per-plate type assignment in schema~~ — **done** (PR #1932 lineage; landed as layered `ArmorPlate`/`ArmorLayer` + `armor-models.ts`) | —            |
+| ~~C2.2~~     | ~~Add new ammo types to `ammoDesigns`, `Magazine` (`max_*`/`count_*`), `chain-gun` (`use_*`)~~ — **done** (PR #1932 lineage; 9 ammo types)       | —            |
+| ~~C2.3~~     | ~~Armor-type-aware damage matrix in `damage-manager.ts`~~ — **done** (PR #1932 lineage; per-layer resolution walk)                               | —            |
+| ~~C2.4~~     | ~~Per-ammo heat values from A4 wired into C1.1~~ — **done** (PR #1932 lineage; `heatPerShot` consumed in `chain-gun-manager.ts`)                 | —            |
+| ~~C2.5~~     | ~~Magazine capacity per A5~~ — **done** (PR #1932 lineage; per-ammo `max_*` in `magazine.ts`)                                                    | —            |
+| C2.6 **[C]** | Cycle UI improvements (persistent strip, magazine counts, next-preview, optional `Shift+B` / `Shift+V` reverse) | — (A2 done)  |
 
 ### Group C3 — needs User (Track B)
 
@@ -79,18 +79,12 @@ Output: design notes captured to `docs/bridge-playtest/`.
 
 ## Recommended kickoff (parallel-friendly)
 
-**Right now, in parallel:**
-- **You** draft B1, B3 (most blocking). Cheap small ones any time: B5, B7, B8.
-- **Daniel** drafts A1, A2 (most blocking).
-- **Claude** executes C1.1, C1.3 — all agent-ready, can run in parallel.
+*Updated 2026-07-20: the first and second waves are largely delivered — Track A (A1–A5) and C2.1–C2.5 shipped via PR #1932; C1.1 and C1.3 landed via #1930 / #1933.*
 
-**Second wave (after B1/B3/A1/A2 land):**
-- Claude executes C3.1+C3.2 (scan geometry), C3.5 (repair engine), C2.1+C2.2 (armor + missile types).
-- Daniel works on A3, A4, A5.
-- You work on B2, B4.
-
-**Third wave:**
-- Claude integrates: C2.3, C2.4, C2.6, C3.3, C3.4, C3.6, C3.7, C3.8.
+**Remaining work:**
+- **You** draft the B-track designs: B1, B3 (most blocking). Cheap small ones any time: B5, B7, B8. Then B2, B4.
+- **Claude** executes C2.6 (cycle UI, [#1969](https://github.com/starwards/starwards/issues/1969)) — unblocked now.
+- **Claude** executes C3.x as the B designs land: C3.1+C3.2 (scan geometry), C3.5 (repair engine), then C3.3, C3.4, C3.6, C3.7, C3.8.
 - Tuning + playtest.
 
 ---
@@ -98,7 +92,7 @@ Output: design notes captured to `docs/bridge-playtest/`.
 ## Cross-cutting notes
 
 - **Per-ship-design ammo loadout** — confirmed 2026-05-03. Cycling stays in the weapons UI (direct-bind dropped).
-- **Heat infra is live.** C1.1 is two function calls; the rest of the chain works today.
+- **Heat infra is live.** C1.1 is done — `chain-gun-manager.ts` calls `addHeat(heatPerShot * effectiveness, chainGun)` on fire (#1930); the rest of the chain works today.
 - **Repair logic is greenfield.** No repair code exists for system damage. C3.5 is the largest single-feature cost in the milestone.
 - **Tier-2 scan is a partial rewrite.** Existing `signals-job-manager.ts` is probabilistic + range-based; new spec is deterministic + geometric. Hack branch is co-located but out of milestone scope — leave behaviour intact.
-- **`ammoDesigns` is hard-coded.** Adding new ammo types touches chain-gun, magazine, projectile, damage-manager, and ship configs together. Expect bugs at the seams.
+- **`ammoDesigns` is hard-coded.** The 9-type integration has landed (PR #1932) across chain-gun, magazine, projectile, damage-manager, and ship configs; the const itself remains hard-coded in `projectile.ts`.

--- a/docs/bridge-playtest/plan.md
+++ b/docs/bridge-playtest/plan.md
@@ -6,21 +6,13 @@ Concrete task breakdown for the next milestone, derived from [`decisions.md`](de
 - **[U]** = User designs (damage control / scan beam control / closed-transponder cost)
 - **[C]** = Claude executes (straightforward, agent-ready once spec'd)
 
-For deferred ideas, see [`proposals.md`](proposals.md).
+For deferred ideas, see [`proposals.md`](proposals.md). For work already shipped, see [Delivered](#delivered) at the foot of this doc.
 
 ---
 
 ## Track A — Daniel-designed (armor + ammo)
 
-| ID         | Task                                                     | Blocked on |
-| ---------- | -------------------------------------------------------- | ---------- |
-| ~~A1~~     | ~~Armor plate types: names, properties, visual identity~~ — **done** (shipped via PR #1932, 2026-07; 5 armor models in `armor-models.ts`)         | —          |
-| ~~A2~~     | ~~Ammo types (missiles + cannon shells): names, properties~~ — **done** (shipped via PR #1932, 2026-07; 3 shells + 6 missiles in `projectile.ts`) | —          |
-| ~~A3~~     | ~~Full armor × ammo damage matrix~~ — **done** (shipped via PR #1932, 2026-07; resolved per-layer in `damage-manager.ts`)                         | —          |
-| ~~A4~~     | ~~Per-ammo heat-per-shot values~~ — **done** (shipped via PR #1932, 2026-07; `heatPerShot` per ammo design)                                       | —          |
-| ~~A5~~     | ~~Per-ammo magazine capacity rules (per-ship-design)~~ — **done** (shipped via PR #1932, 2026-07; `max_*` fields in `magazine.ts`)                | —          |
-
-Output: design spec docs in `docs/bridge-playtest/`.
+Fully delivered — see [Delivered](#delivered).
 
 ---
 
@@ -42,25 +34,13 @@ Output: design notes captured to `docs/bridge-playtest/`.
 
 ## Track C — Claude executes
 
-### Group C1 — independent, ready to start
+Group C1 (independent) and C2.1–C2.5 (armor + ammo integration) are fully delivered — see [Delivered](#delivered). Remaining Claude work:
 
-| ID           | Task                                                                                                     | GitHub                                                      |
-| ------------ | -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| ~~C1.1~~     | ~~Wire `addHeat()` calls into chain-gun + missile firing path~~ — **done** (merged via #1930)            | [#1923](https://github.com/starwards/starwards/issues/1923) |
-| ~~C1.2~~     | ~~Add `callsign` + `transponderOpen` fields to `Spaceship`, default open~~ — **done** (merged via #1927) | [#1924](https://github.com/starwards/starwards/issues/1924) |
-| ~~C1.3~~     | ~~5-second in-range timer for ScanLevel.UFO→BASIC promotion; gate on `transponderOpen`~~ — **done** (merged via #1933) | [#1925](https://github.com/starwards/starwards/issues/1925) |
-| ~~C1.4~~     | ~~Ammo selection UI audit~~ — **done** (resolved by screenshot review on 2026-05-03)                     | —                                                           |
-
-### Group C2 — needs Daniel (Track A)
+### Group C2 — weapons UI
 
 | ID           | Task                                                                                                            | Blocked on   |
 | ------------ | --------------------------------------------------------------------------------------------------------------- | ------------ |
-| ~~C2.1~~     | ~~`ArmorType` enum + per-plate type assignment in schema~~ — **done** (PR #1932 lineage; landed as layered `ArmorPlate`/`ArmorLayer` + `armor-models.ts`) | —            |
-| ~~C2.2~~     | ~~Add new ammo types to `ammoDesigns`, `Magazine` (`max_*`/`count_*`), `chain-gun` (`use_*`)~~ — **done** (PR #1932 lineage; 9 ammo types)       | —            |
-| ~~C2.3~~     | ~~Armor-type-aware damage matrix in `damage-manager.ts`~~ — **done** (PR #1932 lineage; per-layer resolution walk)                               | —            |
-| ~~C2.4~~     | ~~Per-ammo heat values from A4 wired into C1.1~~ — **done** (PR #1932 lineage; `heatPerShot` consumed in `chain-gun-manager.ts`)                 | —            |
-| ~~C2.5~~     | ~~Magazine capacity per A5~~ — **done** (PR #1932 lineage; per-ammo `max_*` in `magazine.ts`)                                                    | —            |
-| C2.6 **[C]** | Cycle UI improvements (persistent strip, magazine counts, next-preview, optional `Shift+B` / `Shift+V` reverse) | — (A2 done)  |
+| C2.6 **[C]** | Cycle UI improvements (persistent strip, magazine counts, next-preview, optional `Shift+B` / `Shift+V` reverse) | — (ready)    |
 
 ### Group C3 — needs User (Track B)
 
@@ -77,13 +57,10 @@ Output: design notes captured to `docs/bridge-playtest/`.
 
 ---
 
-## Recommended kickoff (parallel-friendly)
+## Recommended sequence
 
-*Updated 2026-07-20: the first and second waves are largely delivered — Track A (A1–A5) and C2.1–C2.5 shipped via PR #1932; C1.1 and C1.3 landed via #1930 / #1933.*
-
-**Remaining work:**
 - **You** draft the B-track designs: B1, B3 (most blocking). Cheap small ones any time: B5, B7, B8. Then B2, B4.
-- **Claude** executes C2.6 (cycle UI, [#1969](https://github.com/starwards/starwards/issues/1969)) — unblocked now.
+- **Claude** executes C2.6 (cycle UI, [#1969](https://github.com/starwards/starwards/issues/1969)) — ready now.
 - **Claude** executes C3.x as the B designs land: C3.1+C3.2 (scan geometry), C3.5 (repair engine), then C3.3, C3.4, C3.6, C3.7, C3.8.
 - Tuning + playtest.
 
@@ -96,3 +73,16 @@ Output: design notes captured to `docs/bridge-playtest/`.
 - **Repair logic is greenfield.** No repair code exists for system damage. C3.5 is the largest single-feature cost in the milestone.
 - **Tier-2 scan is a partial rewrite.** Existing `signals-job-manager.ts` is probabilistic + range-based; new spec is deterministic + geometric. Hack branch is co-located but out of milestone scope — leave behaviour intact.
 - **`ammoDesigns` is hard-coded.** The 9-type integration has landed (PR #1932) across chain-gun, magazine, projectile, damage-manager, and ship configs; the const itself remains hard-coded in `projectile.ts`.
+
+---
+
+## Delivered
+
+Completed tasks, collapsed to unblock the tables above. Detail lives in git history and the linked PRs.
+
+- **Track A (A1–A5)** — armor plate types, ammo types, full armor × ammo damage matrix, per-ammo heat-per-shot, per-ammo magazine capacity. Shipped via **PR #1932** (2026-07): 5 armor models (`armor-models.ts`), 3 shells + 6 missiles (`projectile.ts`), per-layer resolution (`damage-manager.ts`), `heatPerShot` per design, `max_*` capacity (`magazine.ts`).
+- **C1.1** — weapons-fire heat wiring. **#1930** (closes #1923); `chain-gun-manager.ts` calls `addHeat`.
+- **C1.2** — `callsign` + `transponderOpen` on `Spaceship`. **#1927** (closes #1924).
+- **C1.3** — 5s in-range UFO→BASIC scan promotion, transponder-gated. **#1933** (closes #1925); `TIER1_DWELL_SECONDS` in `signals-job-manager.ts`.
+- **C1.4** — ammo selection UI audit. Resolved by screenshot review 2026-05-03.
+- **C2.1–C2.5** — armor/ammo integration (PR #1932 lineage): layered `ArmorPlate`/`ArmorLayer` schema, 9 ammo types across `ammoDesigns`/`Magazine`, armor-type-aware matrix, per-ammo heat, magazine capacity.

--- a/docs/bridge-playtest/signals-design.md
+++ b/docs/bridge-playtest/signals-design.md
@@ -68,7 +68,7 @@ Source of facts: `docs/bridge-playtest/signals.md`. Tabular delta:
 |---|---|---|
 | C1 long-range radar with zoom | ✅ `longRangeRadar` widget, 50km default, presets up to 250km, mouse wheel + header + `=`/`-` keys | none |
 | C2 target selection | ✅ `]` / `[` cycle, `'` clear; client-side `SelectionContainer` (independent of `/weaponsTarget`) | filters not implemented (unknown-only / enemy-only) |
-| C3 scan as mini-game | 🟡 a queue-job scan mechanic exists in core (Signals.jobs queue + SignalsJobManager: JobType.SCAN jobs with duration/progress that advance scan level UFO→BASIC→ADVANCED), but it is NOT wired to the signals station UI — no client sends submitJobCommand, so in practice scan level is still GM-controlled via the tweak panel | wire the existing core scan-job mechanic to the signals station UI; no mini-game form exists yet |
+| C3 scan as mini-game | 🟡 a queue-job scan mechanic exists in core (Signals.jobs queue + SignalsJobManager: JobType.SCAN jobs with duration/progress that advance scan level UFO→BASIC→ADVANCED), but it is NOT wired to the signals station UI — no client sends submitJobCommand. Tier-1 (UFO→BASIC) now auto-promotes after 5s of radar dwell with an open transponder (#1925); tier-2 (BASIC→ADVANCED) is still GM-controlled via the tweak panel | wire the existing core scan-job mechanic to the signals station UI; no mini-game form exists yet |
 | C4 read scan results | 🟡 radar blip rendering is gated by scan level (`fc54991`/#1205): UFO = gray dot, BASIC/ADVANCED = sprite + ID. **`targetInfo` widget on signals does NOT gate by scan level** — it always shows Type + Faction + Distance + Bearing. No "model" field. No tactical intel for weapons. | scan-level gating in `targetInfo`; add model and intel fields; potentially expose intel to weapons station |
 | C5 cyber attack | 🟡 the **effect side** of hacking systems exists (#1207 closed) — `SystemState.hacked` is in the data model and reduces effectiveness via `power × coolantFactor × (1 - hacked)`. **No way for the signals officer to initiate a hack**; it is GM-controlled today. | initiation flow + system-selection UI + mini-game (or whatever interaction model is chosen) |
 
@@ -136,10 +136,13 @@ For a bridge playtest where signals is supposed to be the eyes-and-cyber
 seat, the effective outcome today is:
 
 - The signals officer can **see further** than weapons and **point at
-  things**, but cannot **find out what they are** or **interfere with
-  them** without GM intervention.
-- The "feed weapons" loop works only insofar as the GM advances scan
-  levels; otherwise weapons sees the same anonymous gray dots as signals.
+  things**. Tier-1 identification (UFO→BASIC) now happens automatically
+  after 5s of radar dwell on an open transponder (#1925), but the officer
+  still cannot **dig deeper** (tier-2) or **interfere with targets**
+  without GM intervention.
+- The "feed weapons" loop works for basic identification via the tier-1
+  auto-promotion; anything beyond BASIC still requires the GM to advance
+  scan levels.
 
 ## 5. Tickets relevant to closing the gap
 

--- a/docs/bridge-playtest/signals.md
+++ b/docs/bridge-playtest/signals.md
@@ -94,8 +94,11 @@ exists today:
 - `#1205` scan levels mechanic — ✅ **closed**; visibility gating +
   per-faction scan-level state shipped via `fc54991`. The **scan-progression**
   rules (active scanning that lifts UFO → BASIC → ADVANCED via player action)
-  are explicitly out of scope for #1205 — they belong to #1206. Today scan
-  level is GM-tweak-driven.
+  are explicitly out of scope for #1205 — they belong to #1206. Tier-1
+  (UFO→BASIC) now auto-promotes after 5 seconds of continuous radar dwell,
+  gated on an open transponder (#1925, via `signals-job-manager.ts`);
+  tier-2 (BASIC→ADVANCED) is still GM-tweak-driven pending the scan-beam
+  work.
 - `#1206` signals jobs system — core implemented (PR #1878): `SignalsJobManager`
   runs scan/hack jobs and promotes scan levels server-side. No player-facing UI
   wires the queue/submit commands yet, so jobs are not yet reachable from the
@@ -112,8 +115,9 @@ exists today:
 - No "model" readout (would need scan-level BASIC).
 - No filter UI — cannot reduce target-cycle list to "unknown only" or
   "enemy only" as #1208 requires.
-- No way to issue a scan job from the signals seat — scan levels can only
-  be changed via GM tweak panel today.
+- No way to issue a scan job from the signals seat — tier-1 (UFO→BASIC)
+  auto-promotes after 5s in radar range with an open transponder (#1925),
+  but tier-2 (BASIC→ADVANCED) can only be changed via GM tweak panel today.
 - `targetInfo` polls every 200ms via `EmitterLoop` — distance/bearing are
   smooth-ish but not synced with the radar tick.
 - Help modal lists 6 hotkeys + SPACE; no on-screen affordance for filters

--- a/docs/bridge-playtest/weapons.md
+++ b/docs/bridge-playtest/weapons.md
@@ -49,8 +49,9 @@ their tracer fire even past sensor range).
   widget passes `shipDriver.state.faction` to `ObjectsLayer`, so this gating
   is active here. *Caveat:* the **scan-level upgrade mechanism** (signals
   jobs that lift a target from UFO → BASIC → ADVANCED) is **not** part of
-  this ticket — that's #1206 (still open). Today scan level is GM-controlled
-  via tweak panel.
+  this ticket — that's #1206 (still open). Today tier-1 (UFO → BASIC)
+  auto-promotes after a 5s dwell on an open transponder (#1925); further
+  promotion is GM-controlled via tweak panel.
 - `3010cca` — chaingun widget wired into weapons station screen.
 - `ba492f8` — interactive hotkey help modal (SPACE).
 
@@ -60,7 +61,7 @@ their tracer fire even past sensor range).
 |---|---|---|---|
 | #745 | open (partial) | target view when out of radar range | server-side targeting clear shipped (`bb379fa`); ticket file still open — verify residual scope on GitHub |
 | #833 | open, **no milestone** | combine armor plates with tactical radar (single-pilot) | optional — would render armor as a tactical-radar overlay so weapons officer sees self-armor without a separate widget |
-| #1233 | open (MS3) | broken status in damage report widget | adds offline indicator; affects `systemsStatus` (visible top-right) and any other damage-report widget if used |
+| #1233 | ✅ closed (PR #1974) | broken status in damage report widget | done — `damage-report.tsx` now shows broken systems via `getBrokenSystems`; not a widget on this screen |
 | #1206 | open (MS3, blocks #1208) | signals jobs system | indirect: when implemented, target scan-level is no longer GM-controlled — what weapons can identify will change dynamically |
 | #1208 | open (MS3) | signals station | indirect — same as #1206; the dependency chain is the relevant part |
 

--- a/docs/design/links.md
+++ b/docs/design/links.md
@@ -17,7 +17,7 @@
 ## Supporting Libraries
 - **colyseus-events:** Event-driven bridge for Colyseus state sync; enables Node-RED integration
 - **tweakpane-table:** Tweakpane v4 plugin for table UI components (debug/control interfaces)
-- **arwes fork:** `@arwes-amir/*` packages — sci-fi UI framework (React 19 compatible)
+- **arwes:** `@arwes/react` (upstream package, next-channel prerelease) — sci-fi UI framework, used with React 18; version in code repo `modules/browser/package.json`
 - **JSON Schema:** schema/ (sibling folder) — shared data schemas
 
 ## Key Issue Labels


### PR DESCRIPTION
A four-agent audit (2026-07-20) found the docs lagging behind the mid-July merges (#1932 armor+ammo, #1930 heat wiring, #1933 scan promotion, #1974 damage-report fix). This PR is docs-only; every correction was verified against current code before writing.

## bridge-playtest working docs
- **plan.md**: A1–A5, C1.1, C1.3, C2.1–C2.5 struck through as done with PR refs; kickoff section rewritten to the actual remaining work (B-track designs, C2.6, C3.x); cross-cutting notes refreshed ("repair logic is greenfield" verified still true and kept).
- **decisions.md**: dated status note that PR #1932 merged 2026-07-15 (shipped as 9 ammo types); addHeat claim corrected.
- **bridge-eng.md / bridge-eng-design.md / weapons.md**: #1233 marked closed (PR #1974); #968 armor characterization updated from "binary plate state" to the layered per-plate/per-layer model.
- **signals.md / signals-design.md / weapons.md**: "scan level is GM-tweak-driven" corrected — tier-1 (UFO→BASIC) now auto-promotes after 5s dwell on an open transponder (#1925); tier-2 remains GM-only pending the scan-beam work.

## reference docs
- **PHYSICS.md / SUBSYSTEMS.md**: pre-rework armor pseudocode (`findClosestArmorPlate`, `plate.health -=`, `armor.takeDamage`, `PENETRATION_FACTOR`, `damageRandomSystem` — none exist) replaced with the real `walkArmorLayers` outside-in flow + probabilistic `@defectible` system damage; Signals added to the subsystems catalog; phantom "Aegis-12" name dropped.
- **UI_SPECIFICATION.md**: dead armor JSON pointers fixed (`/armor/armorPlates[*]/layers[*]/health`, `/armor/layerDesigns[*]/plateMaxHealth`).
- **API_REFERENCE.md**: `signals` added to the ShipState systems enumeration.
- **design/links.md**: arwes entry corrected (upstream `@arwes/react` prerelease on React 18; no `@arwes-amir/*` fork).

Companion design-repo PR: starwards/starwards-design#5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)