### PR TITLE
refactor: contact-fuze impact damage as a single center-to-center point

### DIFF
--- a/modules/core/src/logic/space-manager.ts
+++ b/modules/core/src/logic/space-manager.ts
@@ -2,6 +2,7 @@ import { Asteroid, Faction, ScanLevel, Spaceship, Waypoint } from '../space';
 import { Body, Circle, System } from 'detect-collisions';
 import { Explosion, Projectile, SpaceObject, SpaceState, Vec2, XY } from '../';
 import {
+    EPSILON,
     FieldOfView,
     Tuple2,
     circlesIntersection,
@@ -531,30 +532,25 @@ export class SpaceManager implements Updateable {
         }
         const flatDamage = warhead.damage;
         if (Spaceship.isInstance(hit)) {
-            const damageBoundries = circlesIntersection(hit, projectile);
-            if (damageBoundries) {
-                const hitLocalDamageBoundries: [XY, XY] = [
-                    hit.globalToLocal(XY.difference(damageBoundries[0], hit.position)),
-                    hit.globalToLocal(XY.difference(damageBoundries[1], hit.position)),
-                ];
-                const hitLocalDamageAngles: Tuple2 = [
-                    limitPercision(XY.angleOf(hitLocalDamageBoundries[0])),
-                    limitPercision(XY.angleOf(hitLocalDamageBoundries[1])),
-                ];
-                const damage: Damage = {
-                    id: projectile.id,
-                    amount: flatDamage,
-                    damageSurfaceArc: hitLocalDamageAngles,
-                    damageDurationSeconds: deltaSeconds,
-                    damageType: projectile.damageType,
-                    delivery: 'impact',
-                };
-                const objectDamage = this.objectDamage.get(hit.id);
-                if (objectDamage === undefined) {
-                    this.objectDamage.set(hit.id, [damage]);
-                } else {
-                    objectDamage.push(damage);
-                }
+            // impact is a single point: the bearing from the hull centre to the projectile centre.
+            // arc gets a minimal width so it lands on the one plate facing the hit (a zero-width
+            // arc is rejected by archIntersection).
+            const impactAngle = limitPercision(
+                XY.angleOf(hit.globalToLocal(XY.difference(projectile.position, hit.position))),
+            );
+            const damage: Damage = {
+                id: projectile.id,
+                amount: flatDamage,
+                damageSurfaceArc: [impactAngle, limitPercision(impactAngle + EPSILON)],
+                damageDurationSeconds: deltaSeconds,
+                damageType: projectile.damageType,
+                delivery: 'impact',
+            };
+            const objectDamage = this.objectDamage.get(hit.id);
+            if (objectDamage === undefined) {
+                this.objectDamage.set(hit.id, [damage]);
+            } else {
+                objectDamage.push(damage);
             }
         } else if (Asteroid.isInstance(hit)) {
             hit.health -= flatDamage;

--- a/modules/core/src/logic/space-manager.ts
+++ b/modules/core/src/logic/space-manager.ts
@@ -1,6 +1,5 @@
 import { Asteroid, Faction, ScanLevel, Spaceship, Waypoint } from '../space';
 import { Body, Circle, System } from 'detect-collisions';
-import { Explosion, Projectile, SpaceObject, SpaceState, Vec2, XY } from '../';
 import {
     EPSILON,
     FieldOfView,
@@ -12,6 +11,7 @@ import {
     toDegreesDelta,
     toPositiveDegreesDelta,
 } from '.';
+import { Explosion, Projectile, SpaceObject, SpaceState, Vec2, XY } from '../';
 import { IterationData, Updateable } from '../updateable';
 import { makeId, uniqueId } from '../id';
 


### PR DESCRIPTION
## What

Simplify the damage-arc calculation for contact-fuzed warhead impacts in `SpaceManager.resolveProjectileContactDamage`.

A contact hit is a single point, so the damage bearing is now taken directly from the hull-centre → projectile-centre angle (in the hull's local frame) instead of computing a `circlesIntersection` two-point arc and converting both boundary points.

## Why

The two-point intersection geometry was overkill for a point impact. Center-to-center is the same physical bearing with far less work — the intersection call, two local-frame conversions, and two `angleOf` computations all drop from this path.

## Note

The arc keeps a minimal `EPSILON` width rather than being literally zero-width: `archIntersection` (`formulas.ts:62`) rejects zero-width arcs, so `[impactAngle, impactAngle]` would register no armor hit. The tiny width lands on exactly the one plate facing the impact.

`circlesIntersection` is still used by ship-vs-ship collision damage, so the import stays.

## Verification

- `warhead-fuze` suite — 11 passed
- damage / armor / space-manager / ship-manager suites — 205 passed
- core typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)