### PR TITLE
fix: reflect current scene in gallery page title (closes #1997)

### DIFF
--- a/modules/browser/src/gallery/gallery.ts
+++ b/modules/browser/src/gallery/gallery.ts
@@ -84,6 +84,8 @@ async function loadScene() {
         return;
     }
 
+    document.title = `${currentSceneName} — Starwards Gallery`;
+
     try {
         const app = await scene.setup(container);
         window.__PIXI_SCENE__ = scene;

--- a/modules/e2e/test/visual/gallery.spec.ts
+++ b/modules/e2e/test/visual/gallery.spec.ts
@@ -91,4 +91,14 @@ test.describe('Visual Gallery', () => {
         const panel = page.locator('[data-id="Gallery"]');
         await expect(panel).toBeVisible();
     });
+
+    test('page title reflects the loaded scene', async ({ page }) => {
+        await page.goto(`${gameDriver.baseURL}/gallery.html?scene=pilot-dashboard-stationary`);
+        await expect(page).toHaveTitle('pilot-dashboard-stationary — Starwards Gallery');
+    });
+
+    test('page title stays static for an unknown scene', async ({ page }) => {
+        await page.goto(`${gameDriver.baseURL}/gallery.html?scene=nonexistent-scene`);
+        await expect(page).toHaveTitle('Starwards Visual Gallery');
+    });
 });


### PR DESCRIPTION
Closes #1997

## Summary

The widget gallery (`gallery.html`) kept a static `<title>` regardless of which scene was loaded, making open gallery tabs indistinguishable when comparing widgets side by side.

- `modules/browser/src/gallery/gallery.ts` — `loadScene()` now sets `document.title = `${currentSceneName} — Starwards Gallery`` once a known scene has been resolved.
- With no/unknown scene param, the title is untouched (stays the static `Starwards Visual Gallery` from `templates/gallery.html`).
- Scene switches already navigate via `window.location.href`, so no additional dynamic-title wiring is needed beyond load time.

## Tests

- `modules/e2e/test/visual/gallery.spec.ts` (TDD red→green):
  - `page title reflects the loaded scene` — asserts `toHaveTitle('pilot-dashboard-stationary — Starwards Gallery')` with `?scene=pilot-dashboard-stationary`.
  - `page title stays static for an unknown scene` — asserts the title stays `Starwards Visual Gallery` for `?scene=nonexistent-scene`.
- Full gate: `npm run test:types`, `npm run test:format`, `npm run build`, `npm test` (503 passed, 2 pre-existing skips), `npm run knip` — all clean.
- `npm run test:e2e` — full suite green except one pre-existing flake (`integration.spec.ts: start and stop a game`, unrelated to this change — fails only under full-suite parallel load, passes in isolation when re-run alone).

No visible layout/design change — only the browser tab title text differs, so no screenshots are attached; the e2e title assertions are the required evidence per the issue.

🤖 Automated by Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hb8hqmyUUbnaRKDNCKgxBH)_