### PR TITLE
docs(design): update radar mechanics to the vision-sector model

### DIFF
--- a/docs/design/mechanics/radar.md
+++ b/docs/design/mechanics/radar.md
@@ -10,7 +10,11 @@ Multiple radar types serve different stations:
 - **Navigator radar** (Navigator) — warp topology overlay (designed, not built)
 - **Long-range radar** (Signals) — extended range for intelligence (built; drives the Signals station's main radar view)
 
-Radar range = `maxRange x effectiveness`. Unpowered radar shows nothing.
+A ship's vision is the union of its radar **sectors**. Each radar contributes one wedge — `direction` (ship-relative), `arc`, and a derived `range` — synced to clients so server and stations compute the same field of view. The dragonfly carries an omnidirectional radar (arc pinned to 360°) plus a steerable "Lancet-20" scan beam (5°–90°) pointed from the Signals station (direction/arc sliders + hotkeys).
+
+Each radar design sweeps a constant area (`area = range² · arc`): widening the arc shortens the reach and vice versa. Effectiveness scales the area, so reach scales with √effectiveness; malfunction blends toward a floor area, and an unpowered radar sees nothing at all.
+
+All visibility gates (signals job queueing/progress, tier-1 promotion, weapons target retention) ask one field-of-view test — `SpaceManager.isVisible` — so nothing treats radar as a circle.
 
 ## Scan Levels (Partial)
 
@@ -34,8 +38,6 @@ The Signals station operates through a job queue (max 9 jobs, FIFO execution):
 **Scan:** Upgrade target scan level. 15-30s (Lvl0→1) or 30-60s (Lvl1→2). 70-90% success rate.
 
 **Hack:** Reduce target system effectiveness by 50% for 2-3 minutes. Requires Lvl2 scan. 30-60s duration. 50-70% success rate. 1-minute cooldown per target system.
-
-**Track:** Maintain visibility on a target beyond line-of-sight. Instant, 100% success. Max 3 tracked targets.
 
 System malfunctions degrade job performance: +25% duration, +20% fail chance per defect. At 3+ defects, 50% chance of alerting the target on failure.
 


### PR DESCRIPTION
docs/design/mechanics/radar.md was missed by #1996: it still described radar as `maxRange × effectiveness` and specced the removed Track job. Now describes the sector-union model (omni + steerable constant-area beam, √effectiveness reach, `SpaceManager.isVisible` as the single gate) and drops Track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)