### PR TITLE
fix: port the MVP ship roster to turreted chainGuns

### DIFF
--- a/modules/core/src/configurations/cataphract.ts
+++ b/modules/core/src/configurations/cataphract.ts
@@ -49,12 +49,7 @@ export const cataphractScanBeam = {
     turnSpeed: 30,
 };
 
-/**
- * Spec calls for 2x FWD arc270 + 1x FWD arc60 (60 bps combined). Today's ChainGun field is a
- * single mount with no per-mount bearing/arc — see #2041 (chainGuns[] + arcWidth).
- * TODO(#2041): add the second and third mounts once that lands; until then this lands the main
- * mount only (FWD, matching its own bearing), at its per-mount rate.
- */
+/** Main battery: fitted forward, sweeping 270° — blind only in a 90° cone astern. */
 export const cataphractChaingun = {
     modelName: 'Hailstorm 20RPS Chaingun',
     isInternal: false,
@@ -76,7 +71,14 @@ export const cataphractChaingun = {
     use_ElecMissile: false,
     damage50: 20,
     energyCost: 1,
-    turnSpeed: 0,
+    turnSpeed: 30,
+    arcWidth: 270,
+};
+
+/** Chin mount: same gun on a narrow 60° forward arc, for close-in work dead ahead. */
+export const cataphractChinChaingun = {
+    ...cataphractChaingun,
+    arcWidth: 60,
 };
 
 export const cataphractReactor = {
@@ -207,7 +209,11 @@ export const cataphractTube = {
 
 export const cataphract = {
     properties: cataphractProperties,
-    chainGun: cataphractChaingun,
+    chainGuns: [
+        ['FWD', cataphractChaingun],
+        ['FWD', cataphractChaingun],
+        ['FWD', cataphractChinChaingun],
+    ],
     thrusters: [
         ['STBD', cataphractThruster],
         ['STBD', cataphractThruster],

--- a/modules/core/src/configurations/chaingun-platform.ts
+++ b/modules/core/src/configurations/chaingun-platform.ts
@@ -156,7 +156,7 @@ export const chaingunPlatformSignals = {
 
 export const chaingunPlatform = {
     properties: chaingunPlatformProperties,
-    chainGun: chaingunPlatformChaingun,
+    chainGuns: [['FWD', chaingunPlatformChaingun]],
     thrusters: [],
     tubes: [],
     armor: chaingunPlatformArmor,

--- a/modules/core/src/configurations/dragonfly-mk1.ts
+++ b/modules/core/src/configurations/dragonfly-mk1.ts
@@ -175,7 +175,7 @@ export const dragonflyMK1Signals = {
 
 export const dragonflyMK1 = {
     properties: dragonflyMK1Properties,
-    chainGun: dragonflyMK1Chaingun,
+    chainGuns: [['FWD', dragonflyMK1Chaingun]],
     thrusters: [
         ['STBD', dragonflyMK1Thruster],
         ['PORT', dragonflyMK1Thruster],

--- a/modules/core/src/configurations/dragonfly-mk2.ts
+++ b/modules/core/src/configurations/dragonfly-mk2.ts
@@ -185,7 +185,7 @@ export const dragonflyMK2Tube = {
 
 export const dragonflyMK2 = {
     properties: dragonflyMK2Properties,
-    chainGun: dragonflyMK2Chaingun,
+    chainGuns: [['FWD', dragonflyMK2Chaingun]],
     thrusters: [
         ['STBD', dragonflyMK2Thruster],
         ['PORT', dragonflyMK2Thruster],

--- a/modules/core/src/configurations/freighter.ts
+++ b/modules/core/src/configurations/freighter.ts
@@ -134,7 +134,7 @@ export const freighterSignals = {
 
 export const freighter = {
     properties: freighterProperties,
-    chainGun: null,
+    chainGuns: [],
     thrusters: [
         ['STBD', freighterThruster],
         ['PORT', freighterThruster],

--- a/modules/core/src/configurations/glaive.ts
+++ b/modules/core/src/configurations/glaive.ts
@@ -46,12 +46,7 @@ export const glaiveScanBeam = {
     turnSpeed: 30,
 };
 
-/**
- * Spec calls for 1x PORT arc180 + 1x STBD arc180 (40 bps combined). Today's ChainGun field is a
- * single bolted-forward mount with no per-mount bearing/arc — see #2041 (chainGuns[] + arcWidth).
- * TODO(#2041): split into the two broadside mounts once that lands; until then this lands the
- * main mount only, at its per-mount rate.
- */
+/** Broadside mount: fitted PORT and STBD, each sweeping 180° centred on its own beam. */
 export const glaiveChaingun = {
     modelName: 'Hailstorm 20RPS Chaingun',
     isInternal: false,
@@ -73,7 +68,8 @@ export const glaiveChaingun = {
     use_ElecMissile: false,
     damage50: 20,
     energyCost: 1,
-    turnSpeed: 0,
+    turnSpeed: 30,
+    arcWidth: 180,
 };
 
 export const glaiveReactor = {
@@ -204,7 +200,10 @@ export const glaiveTube = {
 
 export const glaive = {
     properties: glaiveProperties,
-    chainGun: glaiveChaingun,
+    chainGuns: [
+        ['PORT', glaiveChaingun],
+        ['STBD', glaiveChaingun],
+    ],
     thrusters: [
         ['STBD', glaiveThruster],
         ['STBD', glaiveThruster],

--- a/modules/core/src/configurations/gravitas.ts
+++ b/modules/core/src/configurations/gravitas.ts
@@ -204,7 +204,7 @@ export const gravitasTube = {
 
 export const gravitas = {
     properties: gravitasProperties,
-    chainGun: gravitasChaingun,
+    chainGuns: [['FWD', gravitasChaingun]],
     thrusters: [
         ['STBD', gravitasThruster],
         ['PORT', gravitasThruster],

--- a/modules/core/src/configurations/large-station.ts
+++ b/modules/core/src/configurations/large-station.ts
@@ -127,7 +127,7 @@ export const largeStationSignals = {
 
 export const largeStation = {
     properties: largeStationProperties,
-    chainGun: null,
+    chainGuns: [],
     thrusters: [],
     tubes: [],
     armor: largeStationArmor,

--- a/modules/core/src/configurations/predator.ts
+++ b/modules/core/src/configurations/predator.ts
@@ -203,7 +203,7 @@ export const predatorTube = {
 
 export const predator = {
     properties: predatorProperties,
-    chainGun: predatorChaingun,
+    chainGuns: [['FWD', predatorChaingun]],
     thrusters: [
         ['STBD', predatorThruster],
         ['PORT', predatorThruster],

--- a/modules/core/src/configurations/small-station.ts
+++ b/modules/core/src/configurations/small-station.ts
@@ -127,7 +127,7 @@ export const smallStationSignals = {
 
 export const smallStation = {
     properties: smallStationProperties,
-    chainGun: null,
+    chainGuns: [],
     thrusters: [],
     tubes: [],
     armor: smallStationArmor,

--- a/modules/core/test/ship-roster-mvp.spec.ts
+++ b/modules/core/test/ship-roster-mvp.spec.ts
@@ -1,4 +1,4 @@
-import { ShipDesign, ammoTypes, shipConfigurations } from '../src';
+import { ShipDesign, ShipDirectionConfig, ammoTypes, shipConfigurations } from '../src';
 
 type MissileCounts = Partial<Record<(typeof ammoTypes)[number], number>>;
 
@@ -13,7 +13,14 @@ type HullExpectation = {
     rotationCapacity: number;
     thrusters: number;
     thrusterCapacity: number;
-    chainGun: { bps: number; maxRange: number; minRange: number; bulletSpeed: number } | null;
+    chainGuns: Array<{
+        direction: ShipDirectionConfig;
+        bps: number;
+        maxRange: number;
+        minRange: number;
+        bulletSpeed: number;
+        arcWidth: number;
+    }>;
     shells: { HiExpShell: number; ArmPenShell: number; FragShell: number };
     tubes: number;
     missiles: MissileCounts;
@@ -37,7 +44,7 @@ const hulls: HullExpectation[] = [
         rotationCapacity: 205,
         thrusters: 4,
         thrusterCapacity: 300,
-        chainGun: { bps: 8, maxRange: 4500, minRange: 500, bulletSpeed: 1000 },
+        chainGuns: [{ direction: 'FWD', bps: 8, maxRange: 4500, minRange: 500, bulletSpeed: 1000, arcWidth: 360 }],
         shells: { HiExpShell: 960, ArmPenShell: 480, FragShell: 800 },
         tubes: 0,
         missiles: {},
@@ -59,7 +66,7 @@ const hulls: HullExpectation[] = [
         rotationCapacity: 160,
         thrusters: 4,
         thrusterCapacity: 300,
-        chainGun: { bps: 14, maxRange: 4500, minRange: 500, bulletSpeed: 1000 },
+        chainGuns: [{ direction: 'FWD', bps: 14, maxRange: 4500, minRange: 500, bulletSpeed: 1000, arcWidth: 360 }],
         shells: { HiExpShell: 1_680, ArmPenShell: 840, FragShell: 1_400 },
         tubes: 1,
         missiles: { ArmPenMissile: 4 },
@@ -84,7 +91,7 @@ const hulls: HullExpectation[] = [
         rotationCapacity: 45,
         thrusters: 6,
         thrusterCapacity: 300,
-        chainGun: { bps: 30, maxRange: 8_000, minRange: 500, bulletSpeed: 2_000 },
+        chainGuns: [{ direction: 'FWD', bps: 30, maxRange: 8_000, minRange: 500, bulletSpeed: 2_000, arcWidth: 360 }],
         shells: { HiExpShell: 3_600, ArmPenShell: 1_800, FragShell: 3_000 },
         tubes: 2,
         missiles: {
@@ -116,7 +123,7 @@ const hulls: HullExpectation[] = [
         rotationCapacity: 45,
         thrusters: 6,
         thrusterCapacity: 250,
-        chainGun: { bps: 30, maxRange: 7_500, minRange: 500, bulletSpeed: 2_000 },
+        chainGuns: [{ direction: 'FWD', bps: 30, maxRange: 7_500, minRange: 500, bulletSpeed: 2_000, arcWidth: 360 }],
         shells: { HiExpShell: 3_600, ArmPenShell: 1_800, FragShell: 3_000 },
         tubes: 2,
         missiles: { ArmPenMissile: 12, HiExpMissile: 8, TandemMissile: 2 },
@@ -138,8 +145,10 @@ const hulls: HullExpectation[] = [
         rotationCapacity: 25,
         thrusters: 8,
         thrusterCapacity: 150,
-        // main mount only (broadside PORT/STBD 180° mounts land as a single bolted mount pending #2041)
-        chainGun: { bps: 20, maxRange: 8_000, minRange: 500, bulletSpeed: 2_000 },
+        chainGuns: [
+            { direction: 'PORT', bps: 20, maxRange: 8_000, minRange: 500, bulletSpeed: 2_000, arcWidth: 180 },
+            { direction: 'STBD', bps: 20, maxRange: 8_000, minRange: 500, bulletSpeed: 2_000, arcWidth: 180 },
+        ],
         shells: { HiExpShell: 4_800, ArmPenShell: 2_400, FragShell: 4_000 },
         tubes: 2,
         missiles: { ArmPenMissile: 20, HiExpMissile: 6, TandemMissile: 2 },
@@ -164,8 +173,11 @@ const hulls: HullExpectation[] = [
         rotationCapacity: 45,
         thrusters: 8,
         thrusterCapacity: 150,
-        // main mount only (2x FWD 270° + 1x FWD 60°, 60 bps combined, land as a single bolted mount pending #2041)
-        chainGun: { bps: 20, maxRange: 10_000, minRange: 500, bulletSpeed: 2_500 },
+        chainGuns: [
+            { direction: 'FWD', bps: 20, maxRange: 10_000, minRange: 500, bulletSpeed: 2_500, arcWidth: 270 },
+            { direction: 'FWD', bps: 20, maxRange: 10_000, minRange: 500, bulletSpeed: 2_500, arcWidth: 270 },
+            { direction: 'FWD', bps: 20, maxRange: 10_000, minRange: 500, bulletSpeed: 2_500, arcWidth: 60 },
+        ],
         shells: { HiExpShell: 7_200, ArmPenShell: 3_600, FragShell: 6_000 },
         tubes: 4,
         missiles: { ArmPenMissile: 20, HiExpMissile: 4, ElecMissile: 2, TandemMissile: 2 },
@@ -187,7 +199,7 @@ const hulls: HullExpectation[] = [
         rotationCapacity: 25,
         thrusters: 6,
         thrusterCapacity: 100,
-        chainGun: null,
+        chainGuns: [],
         shells: { HiExpShell: 0, ArmPenShell: 0, FragShell: 0 },
         tubes: 0,
         missiles: {},
@@ -212,7 +224,7 @@ const hulls: HullExpectation[] = [
         rotationCapacity: 60,
         thrusters: 0,
         thrusterCapacity: 0,
-        chainGun: null,
+        chainGuns: [],
         shells: { HiExpShell: 0, ArmPenShell: 0, FragShell: 0 },
         tubes: 0,
         missiles: {},
@@ -237,7 +249,9 @@ const hulls: HullExpectation[] = [
         rotationCapacity: 60,
         thrusters: 0,
         thrusterCapacity: 0,
-        chainGun: { bps: 40, maxRange: 12_000, minRange: 2_400, bulletSpeed: 2_500 },
+        chainGuns: [
+            { direction: 'FWD', bps: 40, maxRange: 12_000, minRange: 2_400, bulletSpeed: 2_500, arcWidth: 360 },
+        ],
         shells: { HiExpShell: 4_800, ArmPenShell: 2_400, FragShell: 4_000 },
         tubes: 0,
         missiles: {},
@@ -262,7 +276,7 @@ const hulls: HullExpectation[] = [
         rotationCapacity: 60,
         thrusters: 0,
         thrusterCapacity: 0,
-        chainGun: null,
+        chainGuns: [],
         shells: { HiExpShell: 0, ArmPenShell: 0, FragShell: 0 },
         tubes: 0,
         missiles: {},
@@ -302,14 +316,16 @@ describe('ship roster MVP hull configurations (issue #2042)', () => {
             expect(thrusterDesign.capacity).toBe(hull.thrusterCapacity);
         }
 
-        if (hull.chainGun) {
-            expect(design.chainGun).toBeTruthy();
-            expect(design.chainGun?.bulletsPerSecond).toBe(hull.chainGun.bps);
-            expect(design.chainGun?.maxShellRange).toBe(hull.chainGun.maxRange);
-            expect(design.chainGun?.minShellRange).toBe(hull.chainGun.minRange);
-            expect(design.chainGun?.bulletSpeed).toBe(hull.chainGun.bulletSpeed);
-        } else {
-            expect(design.chainGun).toBeNull();
+        expect(design.chainGuns).toHaveLength(hull.chainGuns.length);
+        for (const [index, [direction, gunDesign]] of design.chainGuns.entries()) {
+            const expected = hull.chainGuns[index];
+            expect(direction).toBe(expected.direction);
+            expect(gunDesign.bulletsPerSecond).toBe(expected.bps);
+            expect(gunDesign.maxShellRange).toBe(expected.maxRange);
+            expect(gunDesign.minShellRange).toBe(expected.minRange);
+            expect(gunDesign.bulletSpeed).toBe(expected.bulletSpeed);
+            // arcWidth is optional in the design; an omitted arc is unrestricted
+            expect(gunDesign.arcWidth ?? 360).toBe(expected.arcWidth);
         }
 
         expect(design.magazine.max_HiExpShell).toBe(hull.shells.HiExpShell);


### PR DESCRIPTION
## Problem

Two PRs landed on `master` ~35 minutes apart and are incompatible, so master does not build:

- **#2044** (turreted guns, closes #2041) replaced `ShipDesign.chainGun: ChaingunDesign | null` with `chainGuns: [ShipDirectionConfig, ChaingunDesign][]` and added `TurretDesign.arcWidth`. It ported only `dragonfly-sf-22`.
- **#2045** (10 MVP roster hulls) added ten configurations written against the old `chainGun` field.

`CI` and `Deploy Preview` fail on master with 16 `TS2561`/`TS2551` errors plus a `game-manager.ts:192` mismatch.

## Fix

- Ports all ten configurations to `chainGuns` (`[['FWD', design]]`, or `[]` for the unarmed freighter and stations).
- #2045 left `TODO(#2041)` notes where the catalog specs multiple mounts but only one could be expressed. #2041 has landed, so those layouts are now real:
  - **glaive** — `1x PORT` + `1x STBD`, `arcWidth: 180`, `turnSpeed: 30` (40 bps combined)
  - **cataphract** — `2x FWD` `arcWidth: 270` + `1x FWD` chin mount `arcWidth: 60` (60 bps combined)
  - Per-mount rate of fire is unchanged; both hulls now reach the combined output `starwards-design/mechanics/ship-catalog-mvp.md` calls for.
- `ship-roster-mvp.spec.ts` now asserts the full mount list per hull — count, bearing, arc, and gun stats.

Traverse rate is not specified by the catalog; `30°/s` was chosen to match the scan-beam mounts in the same configs.

## Verification

`npm run test:types`, `npm run build`, `npm test` (652 passed), `npm run test:format`, `npm run test:e2e` (72 passed) — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)