### PR TITLE
fix(build): pin @colyseus/core to 0.16.24 and propagate overrides into dist/

### DIFF
--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -68,6 +68,13 @@ own, `tsc` did not report a mismatch — it exhausted a 4 GB heap trying to comp
 that had been fine moments earlier. Any module that adds zod must land on the same copy; check with
 `npm ls zod --all` and confirm no `modules/*/node_modules/zod` exists.
 
+**`@colyseus/core` is held at `0.16.24`** via root `overrides`. `0.16.25` was published with an
+unresolved pnpm workspace specifier in its manifest — `"@colyseus/greeting-banner": "workspace:^"` —
+which npm cannot resolve. Root `npm ci` is unaffected because the lockfile pins the resolution, but
+every lockfile-free install fails with `EUNSUPPORTEDPROTOCOL`: `scripts/pkg.js` (the `npm run pkg`
+step that produces `starwards.exe`) and the Dockerfile's `cd dist && npm install --omit=dev`. Lift
+the pin once upstream republishes a fixed manifest.
+
 Note that npm will keep reinstalling a nested copy while `package-lock.json` still has an entry for
 it, even after the override is added — delete the `modules/*/node_modules/zod` entry from the lockfile
 and reinstall.
@@ -89,6 +96,7 @@ and reinstall.
 | eslint | 10.x | eslint-plugin-react peers cap at ^9.7 | Blocked on plugin |
 | colyseus | 0.17/0.18 | Breaking 0.x line (0.16.x adopted) | Dedicated migration |
 | esbuild | 0.26+ | Breaking 0.x minors | Held at 0.25.x |
+| @colyseus/core | 0.16.25 | Published with `workspace:^` in its manifest; breaks every lockfile-free `npm install` | Pinned to 0.16.24 via root `overrides` |
 | zod | any second copy | Duplicate copies make `tsc` OOM rather than error (see Version Pins) | Pinned via root `overrides` |
 
 ## Upgrade Checklist

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
         "ws@^7": "^7.5.11",
         "picomatch@^4": "^4.0.4",
         "form-data@^4": "^4.0.6",
-        "zod": "4.1.12"
+        "zod": "4.1.12",
+        "@colyseus/core": "0.16.24"
     },
     "scripts": {
         "predev": "rimraf ./modules/core/cjs/index.js",

--- a/scripts/post-build.js
+++ b/scripts/post-build.js
@@ -49,6 +49,10 @@ async function getPackage(modulePath) {
             '@starwards/server': 'file:../' + serverPackage,
         };
 
+        // dist/ installs without a lockfile, so it needs the root's dependency overrides to
+        // resolve the same versions npm ci does. Read them rather than restating them.
+        const { overrides } = require(path.resolve(rootPath || '.', 'package.json'));
+
         await writeFile(
             path.join(distPath, 'package.json'),
             JSON.stringify(
@@ -63,6 +67,7 @@ async function getPackage(modulePath) {
                         targets: ['node18-win-x64'], // , 'node18-linux-x64', 'node18-osx-x64'
                     },
                     dependencies,
+                    overrides,
                 },
                 null,
                 2,


### PR DESCRIPTION
## Problem

CI is red on every open PR (e.g. #2183, #2184) in two jobs:

- **CI / Build** — `npm run pkg` → `scripts/pkg.js` runs `npm install --legacy-peer-deps` in `dist/` → `EUNSUPPORTEDPROTOCOL`, so `dist/exec/starwards.exe` is never produced and the artifact upload errors.
- **Deploy Preview / build-push** — Dockerfile `RUN cd dist && npm install --omit=dev` → same error.

```
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:^
```

Root cause is upstream, not in any PR: **`@colyseus/core@0.16.25`** (published 2026-08-10T18:45Z) was released with an unresolved pnpm workspace specifier in its published manifest:

```json
"@colyseus/greeting-banner": "workspace:^"
```

`modules/server` depends on `^0.16.23`. Root `npm ci` is unaffected because `package-lock.json` pins the resolution — only the two **lockfile-free** installs break. master last passed on 2026-08-10T08:09Z, before the bad publish.

## Fix

- Pin `@colyseus/core` to `0.16.24` in root `overrides`.
- `scripts/post-build.js` now copies the root `overrides` into the generated `dist/package.json`. `dist/` installs standalone, so root overrides do not otherwise reach it — the pin alone would not have fixed either failing job. It reads the root manifest rather than restating the list, so there is one edit point.
- Document the pin and the failure mode in `docs/DEPENDENCIES.md`.

`package-lock.json` needed no change; it already resolved 0.16.24.

Lift the pin once upstream republishes a fixed manifest.

## Verification

- `npm run build` → `cd dist && npm install --omit=dev` succeeds; `dist/node_modules/@colyseus/core` resolves to `0.16.24`.
- `npm run test:format` passes (prettier + eslint).
- Isolated repro confirmed the trigger: a bare `npm install @colyseus/core@^0.16.23` fails, `0.16.24` and every other direct dependency install clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)