### PR TITLE
fix: blast armor damage is a bounded per-detonation warhead property, not a function of shell speed/target diameter (closes #2236)

### DIFF
--- a/modules/core/src/logic/space-manager.ts
+++ b/modules/core/src/logic/space-manager.ts
@@ -782,10 +782,12 @@ export class SpaceManager implements Updateable {
                     positionChange = res.positionChange;
                     Vec2.add(subject.velocity, res.velocityChange, subject.velocity);
                     this.clampToAbsoluteMaxSpeed(subject);
-                    if (Spaceship.isInstance(subject)) {
-                        this.handleShipCollisionDamage(deltaSeconds, res.damageAmount, subject, object, response);
-                    } else if (Asteroid.isInstance(subject)) {
-                        subject.health -= res.damageAmount;
+                    if (res.damageAmount > 0) {
+                        if (Spaceship.isInstance(subject)) {
+                            this.handleShipCollisionDamage(deltaSeconds, res.damageAmount, subject, object, response);
+                        } else if (Asteroid.isInstance(subject)) {
+                            subject.health -= res.damageAmount;
+                        }
                     }
                 }
                 if (positionChange) {
@@ -823,8 +825,18 @@ export class SpaceManager implements Updateable {
             // a much bigger mass. Damage is untouched -- only the physical pushback scales down
             // (issue #2092 design redirect).
             const massScale = (BLAST_IMPULSE_MASS_REFERENCE_RADIUS / subject.radius) ** 3;
+            // A warhead detonates once against a given target: damageFactor is the blast's flat,
+            // bounded per-detonation figure, not a per-second rate to integrate over however long
+            // the (possibly still-moving, still-growing) cloud happens to overlap the hull -- that
+            // integral made the outcome a function of shell speed and target diameter instead of
+            // the warhead (issue #2236). The impulse below is unrelated physical pushback and
+            // keeps accruing every tick of physical overlap, same as before.
+            const alreadyDetonatedOnTarget = object.hitObjectIds.has(subject.id);
+            if (!alreadyDetonatedOnTarget) {
+                object.hitObjectIds.add(subject.id);
+            }
             return {
-                damageAmount: object.damageFactor * deltaSeconds * Math.min(response.overlap, object.radius * 2),
+                damageAmount: alreadyDetonatedOnTarget ? 0 : object.damageFactor,
                 positionChange: null,
                 velocityChange: XY.scale(response.overlapV, -exposure * object.blastFactor * massScale),
             };
@@ -838,6 +850,24 @@ export class SpaceManager implements Updateable {
         }
     }
 
+    /**
+     * The footprint used to size a hit's damage arc. An explosion detonates once per target
+     * (see calcSolidCollision), on whichever tick collision detection first notices the overlap
+     * -- which can be well before the blast has finished growing. The warhead's actual reach is
+     * its fully-grown radius (current radius plus whatever it still gains over its remaining
+     * lifetime), not however far it happened to have expanded by that tick, so the one detonation
+     * event is sized off the former (issue #2236). Every other collider uses its live geometry.
+     */
+    private damageFootprint(object: SpaceObject) {
+        if (Explosion.isInstance(object)) {
+            return {
+                position: object.position,
+                radius: object.radius + object.expansionSpeed * object.secondsToLive,
+            };
+        }
+        return object;
+    }
+
     private handleShipCollisionDamage(
         deltaSeconds: number,
         damageAmount: number,
@@ -845,7 +875,7 @@ export class SpaceManager implements Updateable {
         object: SpaceObject,
         response: SWResponse,
     ) {
-        const damageBoundries = circlesIntersection(subject, object);
+        const damageBoundries = circlesIntersection(subject, this.damageFootprint(object));
         if (damageBoundries) {
             const shipLocalDamageBoundries: [XY, XY] = [
                 subject.globalToLocal(XY.difference(damageBoundries[0], subject.position)),

--- a/modules/core/src/ship/attack-resolution-manager.ts
+++ b/modules/core/src/ship/attack-resolution-manager.ts
@@ -7,8 +7,9 @@ import { ArmorPlate } from './armor';
 import { ShipState } from './ship-state';
 
 /**
- * Explosion damage arrives per tick (damageFactor × dt × capped overlap), so this is
- * calibrated for sanding over a full cloud pass (a handful of small defects), not instant kills.
+ * A blast's surface scrape is one detonation event, sized off the warhead's flat damageFactor
+ * (issue #2236) — this scales that single application down to a handful of small defects on the
+ * hull-mounted systems it reaches, not an instant kill.
  */
 const SURFACE_EFFECT_FACTOR = 0.05;
 
@@ -204,8 +205,14 @@ export class AttackResolutionManager {
             if (plate.broken) {
                 breachHit = true;
             }
-            const share = overlap / hitSize;
-            const chain = this.walkPlateLayers(plate, damage, damage.amount * share, cellBudget);
+            // A blast is one detonation event that reaches every plate inside its radius at the
+            // same intensity: a wider blast touches more plates, not a thinner one (issue #2236).
+            // An impact round's hit arc is a single point (EPSILON-wide, see
+            // resolveProjectileContactDamage) so it only ever lands on one plate; sharing its
+            // total by that plate's fraction of the hit is a no-op there, but matters on the rare
+            // impact that straddles a plate seam.
+            const amount = damage.delivery === 'explosion' ? damage.amount : damage.amount * (overlap / hitSize);
+            const chain = this.walkPlateLayers(plate, damage, amount, cellBudget);
             exposureSum += chain * overlap;
         }
         return { exposure: exposureSum / totalAreaDegrees, breachHit };

--- a/modules/core/src/space/explosion.ts
+++ b/modules/core/src/space/explosion.ts
@@ -44,6 +44,15 @@ export class Explosion extends SpaceObjectBase {
     @gameField('string')
     public readonly type = 'Explosion';
 
+    /**
+     * server-side only, not synced: ids of objects this blast has already dealt its one
+     * detonation event to. A warhead detonates once against a given target — the amount is a
+     * property of the warhead, not an integral of how long the blast geometrically overlapped it
+     * (issue #2236) — so each target this Explosion touches takes damage exactly once, on the
+     * tick it first overlaps, regardless of how many further ticks the overlap physically persists.
+     */
+    public readonly hitObjectIds = new Set<string>();
+
     // server-side only. 'Collision' (e.g. GM-spawned explosions) means a generic
     // hit handled by the flat-damage path.
     private _damageType: SpaceDamageType = 'Collision';

--- a/modules/core/test/armor-ammo-matrix-harness.ts
+++ b/modules/core/test/armor-ammo-matrix-harness.ts
@@ -351,7 +351,7 @@ export function matrixToMarkdown(matrix: Matrix): string {
     );
     lines.push('');
     lines.push(
-        "**Impact and explosion tables are not comparable to each other.** Impact rows apply the warhead's real per-hit `damage`. Real explosion damage accrues per tick as `damageFactor × dt × overlap` over the cloud's lifetime (geometry-dependent); explosion rows here apply one nominal application of `damageFactor × 1s × 1m overlap`, which exercises the armor response but is not a per-shot damage figure. The tables are split so the numbers are not read side by side.",
+        "**Impact and explosion tables are not comparable to each other.** Impact rows apply the warhead's real per-hit `damage`. Explosion rows apply the warhead's real per-detonation `damageFactor` -- a blast is a single detonation event against a given plate, not an integral over dwell time (issue #2236) -- but that single application still isn't a full per-shot figure: a real blast can reach several plates at once (`damageFactor` lands on each), while this rig fires at one plate in isolation. The tables are split so the numbers are not read side by side.",
     );
     lines.push('');
 
@@ -373,7 +373,9 @@ export function matrixToMarkdown(matrix: Matrix): string {
     lines.push('');
     lines.push(...tableFor(impact, 'Shots to breach'));
     lines.push('');
-    lines.push('## Explosion ammo (nominal 1s × 1m application of `damageFactor` — not per-shot damage)');
+    lines.push(
+        '## Explosion ammo (one real per-plate detonation event, `damageFactor` — not a full per-shot total across every plate a real blast reaches)',
+    );
     lines.push('');
     lines.push(...tableFor(explosion, 'Applications to breach'));
     lines.push('');

--- a/modules/core/test/armor-ammo-matrix-report.md
+++ b/modules/core/test/armor-ammo-matrix-report.md
@@ -27,7 +27,7 @@ The design spec defines **deflection**: a deflecting armor (Reactive) pushes an 
 
 Rig: a single plate whose outer layer is the tested model (100 health, the demo-ship baseline) over a composite backing layer that is pre-broken, so observed system damage is governed solely by the tested layer (`makeArmor` requires a composite innermost layer; an intact one engages HiExp/ArmPen/Tandem and would zero the chain for every model). Each application drives `AttackResolutionManager.resolveWeaponAttack` — the exact resolution path a real hit takes — and records plate erosion plus resolved system hits on both channels, split structurally using the documented "surface hits first, then penetration hits" ordering (not by comparing damage amounts). Resolved damage amounts are recorded pre-defect-roll; defects and system breakage are out of scope.
 
-**Impact and explosion tables are not comparable to each other.** Impact rows apply the warhead's real per-hit `damage`. Real explosion damage accrues per tick as `damageFactor × dt × overlap` over the cloud's lifetime (geometry-dependent); explosion rows here apply one nominal application of `damageFactor × 1s × 1m overlap`, which exercises the armor response but is not a per-shot damage figure. The tables are split so the numbers are not read side by side.
+**Impact and explosion tables are not comparable to each other.** Impact rows apply the warhead's real per-hit `damage`. Explosion rows apply the warhead's real per-detonation `damageFactor` -- a blast is a single detonation event against a given plate, not an integral over dwell time (issue #2236) -- but that single application still isn't a full per-shot figure: a real blast can reach several plates at once (`damageFactor` lands on each), while this rig fires at one plate in isolation. The tables are split so the numbers are not read side by side.
 
 ## ⚠ 2 anomalies flagged
 
@@ -64,7 +64,7 @@ Rig: a single plate whose outer layer is the tested model (100 health, the demo-
 | faraday | TandemMissile | Tandem | Transparent | 0 | 1 | 0.00 | n/a (no erosion) | — | 1 / 50.00 | — |
 | faraday | ElecMissile | Elec | Blocked | 0 | 0 | 0.00 | n/a (no erosion) | — | — | — |
 
-## Explosion ammo (nominal 1s × 1m application of `damageFactor` — not per-shot damage)
+## Explosion ammo (one real per-plate detonation event, `damageFactor` — not a full per-shot total across every plate a real blast reaches)
 
 | Armor | Ammo | Type | Outcome | plateDamage | penetration | Plate erosion (1st) | Applications to breach | Surface hits / dmg | Penetration hits / dmg | Anomalies |
 |---|---|---|---|---|---|---|---|---|---|---|

--- a/modules/core/test/armor-layers-examples.spec.ts
+++ b/modules/core/test/armor-layers-examples.spec.ts
@@ -308,9 +308,10 @@ describe('spec §9 worked examples', () => {
             const { ship, state, spaceManager, damageManager } = setUpLayeredShip(fullStack);
             const manager = new ShipManagerPc(ship, state, spaceManager, new MockDie());
             damageManager.takeWeaponDamage(frontDamage(40, 'HiExp', 'explosion'));
-            // each plate's own 1/6 share of the 40 damage erodes its reactive cells (eroded, not popped)
+            // a blast's amount is not divided by the touched-plate count (unlike impact): every
+            // plate takes the same flat erosion, eroding its reactive cells (issue #2236)
             for (const plate of frontPlates(state)) {
-                expect(plate.layers[0].health).to.be.closeTo(100 - 40 / FRONT_PLATE_COUNT, 0.1);
+                expect(plate.layers[0].health).to.be.closeTo(100 - 40, 0.1);
             }
             // scratch the whipple screen too, then run the ship update loop
             frontPlates(state)[0].layers[1].health = 490;
@@ -318,7 +319,7 @@ describe('spec §9 worked examples', () => {
             // armor does not heal — every layer stays at its damaged value until explicit repair
             expect(frontPlates(state)[0].layers[1].health).to.equal(490);
             for (const plate of frontPlates(state)) {
-                expect(plate.layers[0].health).to.be.closeTo(100 - 40 / FRONT_PLATE_COUNT, 0.1);
+                expect(plate.layers[0].health).to.be.closeTo(100 - 40, 0.1);
             }
         });
 

--- a/modules/core/test/armor-walk.spec.ts
+++ b/modules/core/test/armor-walk.spec.ts
@@ -83,8 +83,9 @@ describe('layered armor resolution walk', () => {
         expect(state.smartPilot.offsetFactor).to.equal(0);
     });
 
-    // FRONT_HIT_ARC spans exactly 6 plates, so each plate's own share of a hit is 1/6 of the
-    // damage.amount — none of these hits is confined to a single plate
+    // FRONT_HIT_ARC spans exactly 6 plates. For impact delivery, each plate's own share of a hit
+    // is 1/6 of damage.amount (none of these hits is confined to a single plate). Explosion
+    // delivery does not divide by this count -- see issue #2236.
     const FRONT_PLATE_COUNT = 6;
 
     it('Tandem impact vs Reactive over Composite: pops a cell AND continues into the composite', () => {
@@ -102,8 +103,10 @@ describe('layered armor resolution walk', () => {
         const { state, damageManager } = setUpLayeredShip(reactiveOverComposite);
         const damaged = damageManager.takeWeaponDamage(frontDamage(40, 'HiExp', 'explosion'));
         expect(countBrokenLayer(state, 0)).to.equal(0);
+        // unlike impact, a blast's amount is not divided by the touched-plate count: every plate
+        // inside the blast radius takes the same flat erosion (issue #2236)
         for (const plate of frontPlates(state)) {
-            expect(plate.layers[0].health).to.be.closeTo(100 - 40 / FRONT_PLATE_COUNT, 0.1);
+            expect(plate.layers[0].health).to.be.closeTo(100 - 40, 0.1);
             expect(plate.layers[1].health).to.equal(1000);
         }
         // intact cells, penetration 0 → chain 0 → no internal damage; the surface scrape lands
@@ -124,8 +127,9 @@ describe('layered armor resolution walk', () => {
     it('HiExp explosion erodes the Whipple screen at quarter rate, composite untouched while intact', () => {
         const { state, damageManager } = setUpLayeredShip(whippleOverComposite);
         damageManager.takeWeaponDamage(frontDamage(100, 'HiExp', 'explosion'));
+        // flat per plate (not divided by FRONT_PLATE_COUNT) -- see issue #2236
         for (const plate of frontPlates(state)) {
-            expect(plate.layers[0].health).to.be.closeTo(500 - (100 / FRONT_PLATE_COUNT) * 0.25, 0.1);
+            expect(plate.layers[0].health).to.be.closeTo(500 - 100 * 0.25, 0.1);
             expect(plate.layers[1].health).to.equal(1000);
         }
     });

--- a/modules/core/test/automation-heat-management.spec.ts
+++ b/modules/core/test/automation-heat-management.spec.ts
@@ -365,14 +365,16 @@ describe('AI heat-management automation', () => {
             expect(withoutAutomation.armorLost, 'without automation (baseline)').to.be.greaterThan(0);
             // regression guard: backoff only ever throttles down from the unthrottled baseline, so
             // automation must never deal MORE damage than the baseline — catches e.g. a future change
-            // that silently doubles NPC DPS. Pinned loosely (measured ~33.5 vs ~33.5) to survive minor
-            // tuning: on a stock hull, coolant reallocation alone holds heat clear of the backoff
-            // threshold, so automation costs no offense at all here.
+            // that silently doubles NPC DPS. Pinned loosely (measured ~5.2 vs ~5.2, issue #2236
+            // rebaseline: HiExp blast damage is now a bounded flat per-detonation figure instead of
+            // an unbounded per-tick dwell-time integral) to survive minor tuning: on a stock hull,
+            // coolant reallocation alone holds heat clear of the backoff threshold, so automation
+            // costs no offense at all here.
             expect(withAutomation.armorLost, 'automation must not out-damage the unthrottled baseline').to.be.at.most(
                 withoutAutomation.armorLost,
             );
-            expect(withAutomation.armorLost).to.be.closeTo(33.5, 5);
-            expect(withoutAutomation.armorLost).to.be.closeTo(33.5, 5);
+            expect(withAutomation.armorLost).to.be.closeTo(5.2, 1);
+            expect(withoutAutomation.armorLost).to.be.closeTo(5.2, 1);
             // the actual point of heat management: with it, heat never approaches the ceasefire
             // threshold; without it, the gun sits pegged at the overheat ceiling for the fight
             expect(withAutomation.maxHeat, 'heat management keeps heat well clear of the ceiling').to.be.lessThan(

--- a/modules/core/test/blast-armor-damage.spec.ts
+++ b/modules/core/test/blast-armor-damage.spec.ts
@@ -1,0 +1,219 @@
+import {
+    Armor,
+    Projectile,
+    ShipDesign,
+    ShipManagerNpc,
+    ShipModel,
+    SpaceManager,
+    Spaceship,
+    Vec2,
+    demoShip,
+    makeShipState,
+    shipConfigurations,
+} from '../src';
+
+import { MockDie } from './ship-test-harness';
+import { expect } from 'chai';
+
+/**
+ * Regression coverage for issue #2236: a blast's armor damage was an integral of how long the
+ * (possibly still-moving, still-growing) cloud geometrically overlapped the hull -- a function of
+ * shell speed and target diameter, not of the warhead. These tests pin the fixed property instead:
+ * one detonation, one flat per-plate damage figure derived from the warhead's `damageFactor`,
+ * applied once per target regardless of dwell time or hull size.
+ */
+
+const TICK_SECONDS = 0.01;
+const STANDOFF = 1500; // metres of clear flight before the target, for every fixture below
+const TAIL_SECONDS = 3; // ticks to run after the shell should have detonated, to flush the blast
+
+function totalArmorHealth(armor: Armor): number {
+    let sum = 0;
+    for (const plate of armor.armorPlates) {
+        for (const layer of plate.layers) {
+            sum += layer.health;
+        }
+    }
+    return sum;
+}
+
+function perPlateHealth(armor: Armor): number[] {
+    return [...armor.armorPlates].map((plate) => plate.layers.reduce((s, l) => s + l.health, 0));
+}
+
+/** one stationary target, built from a real hull config (or a custom one) at the origin */
+function makeTarget(hull: ShipModel | ShipDesign, id = 'target') {
+    const config = typeof hull === 'string' ? shipConfigurations[hull] : hull;
+    const ship = new Spaceship();
+    ship.id = id;
+    ship.radius = config.radius;
+    ship.position = Vec2.make({ x: 0, y: 0 });
+    ship.velocity = Vec2.make({ x: 0, y: 0 });
+    const spaceMgr = new SpaceManager();
+    const shipMgr = new ShipManagerNpc(ship, makeShipState(id, config), spaceMgr, new MockDie());
+    spaceMgr.insert(ship);
+    spaceMgr.forceFlushEntities();
+    return { spaceMgr, ship, shipMgr };
+}
+
+/** fires exactly one shell at the target, straight in along the x axis, and lets it play out */
+function fireOneShell(
+    spaceMgr: SpaceManager,
+    shipMgr: ShipManagerNpc,
+    ship: Spaceship,
+    ammo: 'HiExpShell' | 'FragShell' | 'ArmPenShell' | 'HiExpMissile',
+    speed: number,
+) {
+    const shell = new Projectile(ammo);
+    shell.velocity = Vec2.make({ x: speed, y: 0 });
+    shell.init('the-shell', Vec2.make({ x: -(STANDOFF + ship.radius), y: 0 }));
+    if (shell.design.homing) {
+        shell.targetId = ship.id; // guided warheads only proximity-fuze against a tracked target
+    }
+    const flightSeconds = STANDOFF / speed;
+    shell.secondsToLive = flightSeconds + 5;
+    spaceMgr.insert(shell);
+    spaceMgr.forceFlushEntities();
+
+    const totalTicks = Math.ceil((flightSeconds + TAIL_SECONDS) / TICK_SECONDS);
+    for (let i = 0; i < totalTicks; i++) {
+        const id = { deltaSeconds: TICK_SECONDS, deltaSecondsAvg: TICK_SECONDS, totalSeconds: TICK_SECONDS * (i + 1) };
+        spaceMgr.update(id);
+        shipMgr.update(id);
+    }
+}
+
+// a plate large enough that one detonation's flat per-plate figure never breaches it --
+// isolates the property under test (per-plate erosion) from breach/exposure side effects
+const compositeHullAt = (radius: number): ShipDesign => ({
+    ...demoShip,
+    radius,
+    armor: { numberOfPlates: 8, layers: [{ type: 'composite', plateMaxHealth: 1000 }] },
+});
+
+describe('blast armor damage is a property of the warhead (issue #2236)', () => {
+    describe('property 1: independent of shell speed', () => {
+        it('HiExpShell deals the same total armor damage to a given hull at 100, 500 and 2000 m/s', () => {
+            const totals = [100, 500, 2000].map((speed) => {
+                const { spaceMgr, ship, shipMgr } = makeTarget('large-station');
+                const before = totalArmorHealth(shipMgr.state.armor);
+                fireOneShell(spaceMgr, shipMgr, ship, 'HiExpShell', speed);
+                const lost = before - totalArmorHealth(shipMgr.state.armor);
+                expect(lost, `speed ${speed}`).to.be.greaterThan(0);
+                return lost;
+            });
+            const [slow, medium, fast] = totals;
+            expect(fast / slow, 'fast vs slow').to.be.closeTo(1, 0.1);
+            expect(medium / slow, 'medium vs slow').to.be.closeTo(1, 0.1);
+        });
+    });
+
+    describe('property 2: independent of target diameter (same outer-layer model)', () => {
+        it('HiExpShell deals the same per-plate armor damage on hull radii 11, 22, 500 and 1200m', () => {
+            const radii = [11.2, 22.4, 500, 1200];
+            const perPlateAmounts = radii.map((radius) => {
+                const { spaceMgr, ship, shipMgr } = makeTarget(compositeHullAt(radius));
+                const before = perPlateHealth(shipMgr.state.armor);
+                fireOneShell(spaceMgr, shipMgr, ship, 'HiExpShell', 2000);
+                const after = perPlateHealth(shipMgr.state.armor);
+                const touchedLosses = before.map((h, i) => h - after[i]).filter((loss) => loss > 0.01);
+                expect(touchedLosses.length, `radius ${radius}: at least one plate touched`).to.be.greaterThan(0);
+                const avg = touchedLosses.reduce((a, b) => a + b, 0) / touchedLosses.length;
+                for (const loss of touchedLosses) {
+                    expect(loss, `radius ${radius}: every touched plate takes the same amount`).to.be.closeTo(
+                        avg,
+                        avg * 0.05,
+                    );
+                }
+                return avg;
+            });
+            const [r11, r22, r500, r1200] = perPlateAmounts;
+            for (const amount of [r22, r500, r1200]) {
+                expect(amount / r11, 'per-plate amount vs the 11m hull').to.be.closeTo(1, 0.2);
+            }
+        });
+    });
+
+    describe('property 3: total per-detonation damage is bounded, not a function of dwell time', () => {
+        it('running the simulation far past detonation does not keep eroding armor', () => {
+            const { spaceMgr, ship, shipMgr } = makeTarget('large-station');
+            const before = totalArmorHealth(shipMgr.state.armor);
+            fireOneShell(spaceMgr, shipMgr, ship, 'HiExpShell', 500);
+            const justAfter = totalArmorHealth(shipMgr.state.armor);
+            expect(justAfter, 'the shell should have hit').to.be.lessThan(before);
+
+            // several extra seconds with nothing left in flight: a dwell-time integral would have
+            // kept applying damage for as long as anything overlapped; a bounded detonation does not
+            for (let i = 0; i < 500; i++) {
+                const id = { deltaSeconds: TICK_SECONDS, deltaSecondsAvg: TICK_SECONDS, totalSeconds: TICK_SECONDS };
+                spaceMgr.update(id);
+                shipMgr.update(id);
+            }
+            expect(totalArmorHealth(shipMgr.state.armor)).to.equal(justAfter);
+        });
+    });
+
+    describe('property 4: HiExp per-plate erosion preserves the whipple:hardened:composite 0.25:0.5:1 ratio end-to-end', () => {
+        it('through the real space-manager path, not only at the resolution layer', () => {
+            const cases: Array<{ hull: ShipModel; factor: number }> = [
+                { hull: 'gravitas', factor: 0.25 }, // outer layer: whipple
+                { hull: 'large-station', factor: 0.5 }, // outer layer: hardened
+                { hull: 'dragonfly-MK1', factor: 1 }, // outer layer: composite
+            ];
+            const damageFactor = 20; // HiExpShell warhead, spec §8
+            for (const { hull, factor } of cases) {
+                const { spaceMgr, ship, shipMgr } = makeTarget(hull);
+                const before = perPlateHealth(shipMgr.state.armor);
+                fireOneShell(spaceMgr, shipMgr, ship, 'HiExpShell', 2000);
+                const after = perPlateHealth(shipMgr.state.armor);
+                const touchedLosses = before.map((h, i) => h - after[i]).filter((loss) => loss > 0.01);
+                expect(touchedLosses.length, `${hull}: at least one plate touched`).to.be.greaterThan(0);
+                for (const loss of touchedLosses) {
+                    expect(loss, `${hull}: per-plate erosion`).to.be.closeTo(
+                        damageFactor * factor,
+                        damageFactor * factor * 0.1,
+                    );
+                }
+            }
+        });
+    });
+
+    describe('property 5: HiExp deals non-zero armor damage on the smallest hulls at catalog speed', () => {
+        for (const hull of ['dragonfly-MK1', 'gravitas'] as const) {
+            it(`${hull} at 2000 m/s`, () => {
+                const { spaceMgr, ship, shipMgr } = makeTarget(hull);
+                const before = totalArmorHealth(shipMgr.state.armor);
+                fireOneShell(spaceMgr, shipMgr, ship, 'HiExpShell', 2000);
+                expect(totalArmorHealth(shipMgr.state.armor)).to.be.lessThan(before);
+            });
+        }
+
+        it('HiExpMissile also reaches a dragonfly-MK1 at catalog homing speed, same one-detonation property', () => {
+            const { spaceMgr, ship, shipMgr } = makeTarget('dragonfly-MK1');
+            const before = totalArmorHealth(shipMgr.state.armor);
+            fireOneShell(spaceMgr, shipMgr, ship, 'HiExpMissile', 600);
+            expect(totalArmorHealth(shipMgr.state.armor)).to.be.lessThan(before);
+        });
+    });
+
+    describe('property 6: unaffected weapon behaviors (regression guards)', () => {
+        it('FragShell still erodes zero plates on every armor model', () => {
+            for (const hull of ['dragonfly-MK1', 'gravitas', 'large-station'] as const) {
+                const { spaceMgr, ship, shipMgr } = makeTarget(hull);
+                const before = totalArmorHealth(shipMgr.state.armor);
+                fireOneShell(spaceMgr, shipMgr, ship, 'FragShell', 1000);
+                expect(totalArmorHealth(shipMgr.state.armor), hull).to.equal(before);
+            }
+        });
+
+        it('ArmPenShell still spawns no explosion and hits exactly one plate', () => {
+            const { spaceMgr, ship, shipMgr } = makeTarget('large-station');
+            const before = perPlateHealth(shipMgr.state.armor);
+            fireOneShell(spaceMgr, shipMgr, ship, 'ArmPenShell', 1000);
+            expect([...spaceMgr.state.getAll('Explosion')]).to.have.lengthOf(0);
+            const after = perPlateHealth(shipMgr.state.armor);
+            const touchedPlates = before.filter((h, i) => h - after[i] > 0.01).length;
+            expect(touchedPlates).to.equal(1);
+        });
+    });
+});

--- a/modules/core/test/damage-manager-matrix.spec.ts
+++ b/modules/core/test/damage-manager-matrix.spec.ts
@@ -73,9 +73,6 @@ function frontDamage(
 }
 
 describe('damage-manager × armor design stats (issue #1929)', () => {
-    // FRONT_ARC spans exactly 6 plates, so each plate's own share of a hit is 1/6 of the damage.amount
-    const FRONT_PLATE_COUNT = 6;
-
     describe('Reactive armor (single-use cells)', () => {
         it('ArmPen pops cells but is defeated — no system damage on the popping hit', () => {
             const { state, damageManager } = setUpShip(reactiveArmor);
@@ -93,9 +90,10 @@ describe('damage-manager × armor design stats (issue #1929)', () => {
             spaceManager.forceFlushEntities();
             const before = state.armor.armorPlates[0].layers[0].health;
             damageManager.takeWeaponDamage(frontDamage(50, 'HiExp', 'explosion'));
-            // erosion at plateDamage_HiExp (1) — cells wear down instead of popping, using this
-            // plate's own 1/6 share of the 50 damage
-            expect(before - state.armor.armorPlates[0].layers[0].health).to.be.closeTo(50 / FRONT_PLATE_COUNT, 0.001);
+            // erosion at plateDamage_HiExp (1) — cells wear down instead of popping. Unlike
+            // impact, a blast's amount is not divided by the touched-plate count: every plate in
+            // the blast radius takes the same flat erosion (issue #2236)
+            expect(before - state.armor.armorPlates[0].layers[0].health).to.be.closeTo(50, 0.001);
             expect(state.armor.numberOfHealthyPlates).to.equal(state.armor.numberOfPlates);
             expect(explosion.destroyed).to.equal(false);
         });
@@ -163,11 +161,8 @@ describe('damage-manager × armor design stats (issue #1929)', () => {
             const { state, damageManager } = setUpShip(whippleArmor);
             const initial = state.armor.armorPlates[0].layers[0].health;
             const damagedExternals = damageManager.takeWeaponDamage(frontDamage(100, 'HiExp'));
-            // this plate's own 1/6 share of the 100 damage, at quarter rate
-            expect(initial - state.armor.armorPlates[0].layers[0].health).to.be.closeTo(
-                (100 / FRONT_PLATE_COUNT) * 0.25,
-                0.001,
-            );
+            // flat per plate (not divided by FRONT_PLATE_COUNT), at quarter rate -- issue #2236
+            expect(initial - state.armor.armorPlates[0].layers[0].health).to.be.closeTo(100 * 0.25, 0.001);
             expect(damagedExternals).to.equal(true);
         });
 
@@ -191,11 +186,8 @@ describe('damage-manager × armor design stats (issue #1929)', () => {
             const { state, damageManager } = setUpShip(hardenedArmor);
             const before = state.armor.armorPlates[0].layers[0].health;
             damageManager.takeWeaponDamage(frontDamage(100, 'HiExp'));
-            // this plate's own 1/6 share of the 100 damage, at half rate
-            expect(before - state.armor.armorPlates[0].layers[0].health).to.be.closeTo(
-                (100 / FRONT_PLATE_COUNT) * 0.5,
-                0.001,
-            );
+            // flat per plate (not divided by FRONT_PLATE_COUNT), at half rate -- issue #2236
+            expect(before - state.armor.armorPlates[0].layers[0].health).to.be.closeTo(100 * 0.5, 0.001);
         });
 
         it('Frag vs Composite scrapes externals even while plates hold', () => {

--- a/modules/core/test/warhead-fuze.spec.ts
+++ b/modules/core/test/warhead-fuze.spec.ts
@@ -1,4 +1,4 @@
-import { Asteroid, Projectile, SpaceManager, Spaceship, Vec2, XY, ammoDesigns } from '../src';
+import { Asteroid, Damage, Projectile, SpaceManager, Spaceship, Vec2, XY, ammoDesigns } from '../src';
 
 import { expect } from 'chai';
 
@@ -205,7 +205,7 @@ describe('proximity-fuzed warheads (issue #1976)', () => {
         expect(distanceFromHull).to.be.greaterThan(shell.radius); // never actually touched the hull
     });
 
-    it('explosion overlap streams damage events tagged with explosion delivery', () => {
+    it('explosion overlap delivers a damage event tagged with explosion delivery (issue #2236: one detonation event, not a per-tick stream)', () => {
         const spaceMgr = new SpaceManager();
         const ship = makeShip('blast-target');
         const shell = new Projectile('HiExpShell');
@@ -215,12 +215,15 @@ describe('proximity-fuzed warheads (issue #1976)', () => {
         spaceMgr.forceFlushEntities();
 
         tick(spaceMgr, 0.05); // time-fuze detonation next to the hull
-        for (let i = 0; i < 10 && [...spaceMgr.resolveObjectDamage(ship.id)].length === 0; i++) {
+        // resolveObjectDamage drains the queue as it's read, so accumulate across every tick
+        // instead of polling it as the loop condition (that would drain and discard the one
+        // detonation event before the assertions below ever see it)
+        const damageEvents: Damage[] = [];
+        for (let i = 0; i < 10; i++) {
             tick(spaceMgr, 0.05); // let the blast grow into the hull
+            damageEvents.push(...spaceMgr.resolveObjectDamage(ship.id));
         }
-        tick(spaceMgr, 0.05);
 
-        const damageEvents = [...spaceMgr.resolveObjectDamage(ship.id)];
         expect(damageEvents.length).to.be.greaterThan(0);
         for (const damage of damageEvents) {
             expect(damage.delivery).to.equal('explosion');


### PR DESCRIPTION
Closes #2236

## Summary

- Explosion (HiExp/Frag) damage against ships/asteroids was accrued every physics tick as `damageFactor × dt × min(overlap, blastDiameter)` for as long as the (velocity-inheriting, still-growing) blast cloud geometrically overlapped the target — a dwell-time integral, so the same warhead could deal 0 damage on a fast small-ship hit and 150+ on a slow large-station hit. Each `Explosion` now applies its `damageFactor` **exactly once per target it touches** (tracked via a new, unsynced `Explosion.hitObjectIds`), sized against the blast's fully-grown radius (current radius + remaining expansion) rather than however far it had expanded on the tick collision detection first noticed the overlap — so the one detonation event reflects the warhead's actual reach, not a timing accident.
- In the armor resolution walk (`AttackResolutionManager.walkArmorLayers`), an explosion's flat amount now lands on **every touched plate at full intensity**, instead of being divided pro-rata by each plate's share of the hit arc. That division was the second half of the bug: it thinned per-plate damage on any hull whose plate layout put more/narrower plates under the same blast, independent of the dwell-time issue. Impact delivery (contact-fuzed rounds) is unchanged — its hit arc is always a single point, so the division was already a no-op there.
- Armor-model `plateFactor` ratios (whipple 0.25 / hardened 0.5 / composite 1) and the physical blast-impulse pushback (`velocityChange`) are untouched, per the issue's own "not wrong, keep" list.

**Design decision:** I did not remove the explosion's velocity inheritance from the firing shell (the issue flagged it as dead weight now that #2112's fuze guard exists). The one-shot, warhead-sized model above is sufficient on its own to satisfy every acceptance property without touching it, and removing it risked destabilizing detonation timing for guided missiles / near-miss proximity fuzing for no additional correctness benefit.

## Tests

- `modules/core/test/blast-armor-damage.spec.ts` (new) — shooting-range tests pinning the issue's acceptance properties directly, against the real `shipConfigurations` hulls named in the issue (dragonfly-MK1, gravitas, small-station via a same-model synthetic rig, large-station):
  - per-shell armor damage on a given hull is the same at 100/500/2000 m/s (±10%)
  - per-plate armor damage on a same-armor-model hull is the same across radii 11/22/500/1200m (±20%)
  - total per-detonation damage is bounded — running far past detonation doesn't keep eroding armor
  - HiExp preserves the whipple:hardened:composite 0.25:0.5:1 per-plate ratio end-to-end through the real space-manager path (not just the resolution layer)
  - HiExp deals non-zero damage on dragonfly-MK1/gravitas at catalog speed (2000 m/s), including a HiExpMissile check
  - Frag still erodes zero plates on every model; ArmPen still spawns no explosion and hits exactly one plate
- `modules/core/test/armor-ammo-matrix-report.md` regenerated (`UPDATE_ARMOR_MATRIX_REPORT=1 npm test -- modules/core/test/armor-ammo-matrix.spec.ts`) — only the explanatory prose changed (the harness already fed the resolution layer a flat `damageFactor`, so no numeric rows moved).
- Updated pinned unit tests that encoded the old share-divided-by-arc-width behavior for explosion delivery to the new flat-per-plate figures: `armor-walk.spec.ts`, `armor-layers-examples.spec.ts`, `damage-manager-matrix.spec.ts`, `warhead-fuze.spec.ts` (the last also had a test-only bug: it polled `resolveObjectDamage` — which drains its queue on read — as its own loop condition, silently discarding the one detonation event before the final assertion; fixed to accumulate across ticks instead).
- `automation-heat-management.spec.ts`'s sustained-DPS baseline is rebaselined from ~33.5 to ~5.2 armor lost over 600s — HiExp blast damage is now bounded instead of an unbounded dwell-time integral, so the old pin no longer reflects reality. Per the issue, balance retuning (`damageFactor`, station armor totals) is explicitly out of scope; this is a rebaseline of a regression-guard pin to the corrected model, not a balance change.
- Full suite green: `npm run test:types && npm run test:format && npm run build && npm test` (150/150 suites, 1249 passed / 2 pre-existing skips), including the wave-defence and npc-goto-gunnery integration tests named in the issue's acceptance list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AUdAxqRYrbJNCxx8TUK5j3

---
_Generated by [Claude Code](https://claude.ai/code/session_01AUdAxqRYrbJNCxx8TUK5j3)_